### PR TITLE
Introduction of port 7 for tagsl. ⚙️

### DIFF
--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -115,6 +115,26 @@ func (t TagSLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 			},
 			TargetType: reflect.TypeOf(Port6Payload{}),
 		}, nil
+	case 7:
+		return decoder.PayloadConfig{
+			Fields: []decoder.FieldConfig{
+				{Name: "Timestamp", Start: 0, Length: 4},
+				{Name: "Moving", Start: 4, Length: 1},
+				{Name: "Mac1", Start: 5, Length: 6, Optional: true},
+				{Name: "Rssi1", Start: 11, Length: 1, Optional: true},
+				{Name: "Mac2", Start: 12, Length: 6, Optional: true},
+				{Name: "Rssi2", Start: 18, Length: 1, Optional: true},
+				{Name: "Mac3", Start: 19, Length: 6, Optional: true},
+				{Name: "Rssi3", Start: 25, Length: 1, Optional: true},
+				{Name: "Mac4", Start: 26, Length: 6, Optional: true},
+				{Name: "Rssi4", Start: 32, Length: 1, Optional: true},
+				{Name: "Mac5", Start: 33, Length: 6, Optional: true},
+				{Name: "Rssi5", Start: 39, Length: 1, Optional: true},
+				{Name: "Mac6", Start: 40, Length: 6, Optional: true},
+				{Name: "Rssi6", Start: 46, Length: 1, Optional: true},
+			},
+			TargetType: reflect.TypeOf(Port7Payload{}),
+		}, nil
 	case 10:
 		return decoder.PayloadConfig{
 			Fields: []decoder.FieldConfig{

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -173,6 +173,26 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
+			payload: "66ec04bb00e0286d8aabfcbbec6c9a74b58fb2726c9a74b58db1e0286d8a9478cbf0b0140c96bbd2260122180d42ad",
+			port:    7,
+			expected: Port7Payload{
+				Timestamp: time.Date(2024, 9, 19, 11, 2, 19, 0, time.UTC),
+				Moving:    false,
+				Mac1:      "e0286d8aabfc",
+				Rssi1:     -69,
+				Mac2:      "ec6c9a74b58f",
+				Rssi2:     -78,
+				Mac3:      "726c9a74b58d",
+				Rssi3:     -79,
+				Mac4:      "e0286d8a9478",
+				Rssi4:     -53,
+				Mac5:      "f0b0140c96bb",
+				Rssi5:     -46,
+				Mac6:      "260122180d42",
+				Rssi6:     -83,
+			},
+		},
+		{
 			payload: "0002d308b50082457f16eb66c4a5cd0ed3",
 			port:    10,
 			expected: Port10Payload{

--- a/pkg/decoder/tagsl/v1/port7.go
+++ b/pkg/decoder/tagsl/v1/port7.go
@@ -1,0 +1,39 @@
+package tagsl
+
+import "time"
+
+// +------+------+-------------------------------------------+-----------+
+// | Byte | Size | Description                               | Format    |
+// +------+------+-------------------------------------------+-----------+
+// | 0    | 1    | Timestamp                                 | uint8     |
+// | 1    | 1    | Moving                                    | uint8     |
+// | 2    | 6    | MAC1                                      | uint8[6]  |
+// | 8    | 1    | RSSI1                                     | int8      |
+// | 9    | 6    | MAC2                                      | uint8[6]  |
+// | 15   | 1    | RSSI2                                     | int8      |
+// | 16   | 6    | MAC3                                      | uint8[6]  |
+// | 22   | 1    | RSSI3                                     | int8      |
+// | 23   | 6    | MAC4                                      | uint8[6]  |
+// | 29   | 1    | RSSI4                                     | int8      |
+// | 30   | 6    | MAC5                                      | uint8[6]  |
+// | 36   | 1    | RSSI5                                     | int8      |
+// | 37   | 6    | MAC6                                      | uint8[6]  |
+// | 43   | 1    | RSSI6                                     | int8      |
+// +------+------+-------------------------------------------+-----------+
+
+type Port7Payload struct {
+	Timestamp time.Time `json:"timestamp"`
+	Moving    bool      `json:"moving"`
+	Mac1      string    `json:"mac1"`
+	Rssi1     int8      `json:"rssi1"`
+	Mac2      string    `json:"mac2"`
+	Rssi2     int8      `json:"rssi2"`
+	Mac3      string    `json:"mac3"`
+	Rssi3     int8      `json:"rssi3"`
+	Mac4      string    `json:"mac4"`
+	Rssi4     int8      `json:"rssi4"`
+	Mac5      string    `json:"mac5"`
+	Rssi5     int8      `json:"rssi5"`
+	Mac6      string    `json:"mac6"`
+	Rssi6     int8      `json:"rssi6"`
+}


### PR DESCRIPTION
The new port includes a captured time. This reduces the number of mac addresses included in an uplink by one.

Input (port 7): `66EC04BB00E0286D8AABFCBBEC6C9A74B58FB2726C9A74B58DB1E0286D8A9478CBF0B0140C96BBD2260122180D42AD`

```bash
$ decoder tagsl 5 00e0286d8aabfca8e0286d8a9478c2726c9a74b58dab726cdac8b89dacf0b0140c96bbc8

$ decoder tagsl 7 66ec04bb00e0286d8aabfcbbec6c9a74b58fb2726c9a74b58db1e0286d8a9478cbf0b0140c96bbd2260122180d42ad
```

### Port 5:

```json
{
    "mac1": "e0286d8aabfc",
    "mac2": "e0286d8a9478",
    "mac3": "726c9a74b58d",
    "mac4": "726cdac8b89d",
    "mac5": "f0b0140c96bb",
    "mac6": "",
    "mac7": "",
    "moving": false,
    "rssi1": -88,
    "rssi2": -62,
    "rssi3": -85,
    "rssi4": -84,
    "rssi5": -56,
    "rssi6": 0,
    "rssi7": 0
}
```

### Port 7 🆕:
```json
{
    "mac1": "e0286d8aabfc",
    "mac2": "ec6c9a74b58f",
    "mac3": "726c9a74b58d",
    "mac4": "e0286d8a9478",
    "mac5": "f0b0140c96bb",
    "mac6": "260122180d42",
    "moving": false,
    "rssi1": -69,
    "rssi2": -78,
    "rssi3": -79,
    "rssi4": -53,
    "rssi5": -46,
    "rssi6": -83,
    "timestamp": "2024-09-19T11:02:19Z"
}