### PR TITLE
Updated `battery` key to be consistent. 🚧

### DIFF
--- a/pkg/decoder/nomadxs/v1/decoder.go
+++ b/pkg/decoder/nomadxs/v1/decoder.go
@@ -94,7 +94,7 @@ func (t NomadXSv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 		return decoder.PayloadConfig{
 			Fields: []decoder.FieldConfig{
 				{Name: "LowBattery", Start: 0, Length: 1},
-				{Name: "BatteryVoltage", Start: 1, Length: 2, Transform: func(v interface{}) interface{} {
+				{Name: "Battery", Start: 1, Length: 2, Transform: func(v interface{}) interface{} {
 					return float64(v.(int)) / 1000
 				}},
 			},

--- a/pkg/decoder/nomadxs/v1/decoder_test.go
+++ b/pkg/decoder/nomadxs/v1/decoder_test.go
@@ -89,8 +89,8 @@ func TestDecode(t *testing.T) {
 			payload: "010df6",
 			port:    15,
 			expected: Port15Payload{
-				LowBattery:     true,
-				BatteryVoltage: 3.574,
+				LowBattery: true,
+				Battery:    3.574,
 			},
 		},
 	}

--- a/pkg/decoder/nomadxs/v1/port15.go
+++ b/pkg/decoder/nomadxs/v1/port15.go
@@ -8,6 +8,6 @@ package nomadxs
 // +------+------+---------------------------------------------+------------+
 
 type Port15Payload struct {
-	LowBattery     bool    `json:"low_battery"`
-	BatteryVoltage float64 `json:"battery_voltage"`
+	LowBattery bool    `json:"low_battery"`
+	Battery    float64 `json:"battery"`
 }

--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -159,7 +159,7 @@ func (t TagSLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 		return decoder.PayloadConfig{
 			Fields: []decoder.FieldConfig{
 				{Name: "LowBattery", Start: 0, Length: 1},
-				{Name: "BatteryVoltage", Start: 1, Length: 2, Transform: func(v interface{}) interface{} {
+				{Name: "Battery", Start: 1, Length: 2, Transform: func(v interface{}) interface{} {
 					return float64(v.(int)) / 1000
 				}},
 			},

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -208,16 +208,16 @@ func TestDecode(t *testing.T) {
 			payload: "800ee5",
 			port:    15,
 			expected: Port15Payload{
-				LowBattery:     false,
-				BatteryVoltage: 3.813,
+				LowBattery: false,
+				Battery:    3.813,
 			},
 		},
 		{
 			payload: "001044",
 			port:    15,
 			expected: Port15Payload{
-				LowBattery:     false,
-				BatteryVoltage: 4.164,
+				LowBattery: false,
+				Battery:    4.164,
 			},
 		},
 		{

--- a/pkg/decoder/tagsl/v1/port15.go
+++ b/pkg/decoder/tagsl/v1/port15.go
@@ -8,6 +8,6 @@ package tagsl
 // +------+------+---------------------------------------------+------------+
 
 type Port15Payload struct {
-	LowBattery     bool    `json:"low_battery"`
-	BatteryVoltage float64 `json:"battery_voltage"`
+	LowBattery bool    `json:"low_battery"`
+	Battery    float64 `json:"battery"`
 }

--- a/pkg/decoder/tagxl/v1/decoder.go
+++ b/pkg/decoder/tagxl/v1/decoder.go
@@ -32,7 +32,7 @@ func (t TagXLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 		// 		// }},
 		// 		{Name: "HeartbeatInterval", Start: 11, Length: 1, Optional: true},
 		// 		{Name: "AdvertisementFwuInterval", Start: 12, Length: 1},
-		// 		{Name: "BatteryVoltage", Start: 13, Length: 2},
+		// 		{Name: "Battery", Start: 13, Length: 2},
 		// 		{Name: "FirmwareHash", Start: 15, Length: 4},
 		// 	},
 		// 	TargetType: reflect.TypeOf(Port151Payload{}),

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -115,7 +115,7 @@ func TestDecode(t *testing.T) {
 		// 	payload: "4C050145020B8C",
 		// 	port:    151,
 		// 	expected: Port151Payload{
-		// 		BatteryVoltage: 2.956,
+		// 		Battery: 2.956,
 		// 	},
 		// },
 	}

--- a/pkg/decoder/tagxl/v1/port151.go
+++ b/pkg/decoder/tagxl/v1/port151.go
@@ -29,6 +29,6 @@ type Port151Payload struct {
 	AccelerationSensor       []uint16 `json:"accelerationSensor"`
 	HeartbeatInterval        uint8    `json:"heartbeatInterval"`
 	AdvertisementFwuInterval uint8    `json:"advertisementFwuInterval"`
-	BatteryVoltage           float64  `json:"batteryVoltage"`
+	Battery                  float64  `json:"Battery"`
 	FirmwareHash             []uint8  `json:"firmwareHash"`
 }


### PR DESCRIPTION
Renamed all battery voltage related fields to match `battery`.