### PR TITLE
Added decoder config for port `8`. 🎉

### DIFF
--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -138,6 +138,21 @@ func (t TagSLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 			TargetType:      reflect.TypeOf(Port7Payload{}),
 			StatusByteIndex: helpers.ToIntPointer(4),
 		}, nil
+	case 8:
+		return decoder.PayloadConfig{
+			Fields: []decoder.FieldConfig{
+				{Name: "ScanInterval", Start: 0, Length: 2},
+				{Name: "ScanTime", Start: 2, Length: 1},
+				{Name: "MaxBeacons", Start: 3, Length: 1},
+				{Name: "MinRssiValue", Start: 4, Length: 1},
+				{Name: "AdvertisingFilter", Start: 5, Length: 10},
+				{Name: "AccelerometerTriggerHoldTimer", Start: 15, Length: 2},
+				{Name: "AccelerometerThreshold", Start: 17, Length: 2},
+				{Name: "ScanMode", Start: 19, Length: 1},
+				{Name: "BLECurrentConfigurationUplinkInterval", Start: 20, Length: 2},
+			},
+			TargetType: reflect.TypeOf(Port8Payload{}),
+		}, nil
 	case 10:
 		return decoder.PayloadConfig{
 			Fields: []decoder.FieldConfig{

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -193,6 +193,21 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
+			payload: "012c141e9c455738304543434343460078012c01a8c0",
+			port:    8,
+			expected: Port8Payload{
+				ScanInterval:                          300,
+				ScanTime:                              20,
+				MaxBeacons:                            30,
+				MinRssiValue:                          -100,
+				AdvertisingFilter:                     "4048812220199682886",
+				AccelerometerTriggerHoldTimer:         120,
+				AccelerometerThreshold:                300,
+				BLECurrentConfigurationUplinkInterval: 43200,
+				ScanMode:                              1,
+			},
+		},
+		{
 			payload: "0002d308b50082457f16eb66c4a5cd0ed3",
 			port:    10,
 			expected: Port10Payload{

--- a/pkg/decoder/tagsl/v1/port8.go
+++ b/pkg/decoder/tagsl/v1/port8.go
@@ -1,0 +1,26 @@
+package tagsl
+
+// | Byte   | Size | Description                                 | Format                                             |
+// |--------|------|--------------------------------------------|-----------------------------------------------------|
+// | 0-1    | 2    | Scan interval                              | uint16, s                                           |
+// | 2      | 1    | Scan time                                  | uint8, s [0..180]                                   |
+// | 3      | 1    | Max beacons                                | uint8                                               |
+// | 4      | 1    | Min. Rssi value                            | int8                                                |
+// | 5-14   | 10   | Advertising name/eddystone namespace filter | 10 x ASCII or 10 x uint8                           |
+// | 15-16  | 2    | Accelerometer trigger hold timer           | uint16, s                                           |
+// | 17-18  | 2    | Accelerometer threshold                    | uint16, mg                                          |
+// | 19     | 1    | Scan mode                                  | 0 - no filter; 1 - advertised name filter;          |
+// | 		|	   |											| 2 - eddystone namespace filter                      |
+// | 20-21  | 2    | BLE current configuration uplink interval  | uint16, s                                           |
+
+type Port8Payload struct {
+	ScanInterval                          uint16 `json:"scanInterval"`
+	ScanTime                              uint8  `json:"scanTime"`
+	MaxBeacons                            uint8  `json:"maxBeacons"`
+	MinRssiValue                          int8   `json:"minRssiValue"`
+	AdvertisingFilter                     string `json:"advertisingFilter"`
+	AccelerometerTriggerHoldTimer         uint16 `json:"accelerometerTriggerHoldTimer"`
+	AccelerometerThreshold                uint16 `json:"accelerometerThreshold"`
+	ScanMode                              uint8  `json:"scanMode"`
+	BLECurrentConfigurationUplinkInterval uint16 `json:"bleCurrentConfigurationUplinkInterval"`
+}


### PR DESCRIPTION
Added new decoder configuration for uplinks using port `8`.

```bash
decoder tagsl 8 012c141e9c455738304543434343460078012c01a8c0
[16:59:32.243] INFO: successfully decoded payload {
  "data": {
    "accelerometerThreshold": 300,
    "accelerometerTriggerHoldTimer": 120,
    "advertisingFilter": "4048812220199682886",
    "bleCurrentConfigurationUplinkInterval": 43200,
    "maxBeacons": 30,
    "minRssiValue": -100,
    "scanInterval": 300,
    "scanMode": 1,
    "scanTime": 20
  },
  "metadata": null
}
```