### PR TITLE
Fixed invalid `moving` flag. 🚧

### DIFF
--- a/pkg/decoder/helpers/helpers.go
+++ b/pkg/decoder/helpers/helpers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
-func hexStringToBytes(hexString string) ([]byte, error) {
+func HexStringToBytes(hexString string) ([]byte, error) {
 	bytes, err := h.DecodeString(hexString)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func extractFieldValue(payloadBytes []byte, start int, length int, optional bool
 // DecodeLoRaWANPayload decodes the payload based on the provided configuration and populates the target struct
 func Parse(payloadHex string, config decoder.PayloadConfig) (interface{}, error) {
 	// Convert hex payload to bytes
-	payloadBytes, err := hexStringToBytes(payloadHex)
+	payloadBytes, err := HexStringToBytes(payloadHex)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/decoder/helpers/helpers_test.go
+++ b/pkg/decoder/helpers/helpers_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestInvalidHexString(t *testing.T) {
-	_, err := hexStringToBytes("invalid")
+	_, err := HexStringToBytes("invalid")
 	if err == nil {
 		t.Fatalf("expected error while decoding hex string")
 	}
 }
 
 func TestHexStringToBytes(t *testing.T) {
-	_, err := hexStringToBytes("8002cdcd1300744f5e166018040b14341a")
+	_, err := HexStringToBytes("8002cdcd1300744f5e166018040b14341a")
 	if err != nil {
 		t.Fatalf("error decoding hex string: %v", err)
 	}

--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -138,6 +138,21 @@ func (t TagSLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 			TargetType:      reflect.TypeOf(Port7Payload{}),
 			StatusByteIndex: helpers.ToIntPointer(4),
 		}, nil
+	case 8:
+		return decoder.PayloadConfig{
+			Fields: []decoder.FieldConfig{
+				{Name: "ScanInterval", Start: 0, Length: 2},
+				{Name: "ScanTime", Start: 2, Length: 1},
+				{Name: "MaxBeacons", Start: 3, Length: 1},
+				{Name: "MinRssiValue", Start: 4, Length: 1},
+				{Name: "AdvertisingFilter", Start: 5, Length: 10},
+				{Name: "AccelerometerTriggerHoldTimer", Start: 15, Length: 2},
+				{Name: "AccelerometerThreshold", Start: 17, Length: 2},
+				{Name: "ScanMode", Start: 19, Length: 1},
+				{Name: "BLECurrentConfigurationUplinkInterval", Start: 20, Length: 2},
+			},
+			TargetType: reflect.TypeOf(Port8Payload{}),
+		}, nil
 	case 10:
 		return decoder.PayloadConfig{
 			Fields: []decoder.FieldConfig{

--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -43,10 +43,9 @@ func (t TagSLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 		}, nil
 	case 2:
 		return decoder.PayloadConfig{
-			Fields: []decoder.FieldConfig{
-				{Name: "Moving", Start: 0, Length: 1},
-			},
-			TargetType: reflect.TypeOf(Port2Payload{}),
+			Fields:          []decoder.FieldConfig{},
+			TargetType:      reflect.TypeOf(Port2Payload{}),
+			StatusByteIndex: helpers.ToIntPointer(0),
 		}, nil
 	case 3:
 		return decoder.PayloadConfig{
@@ -288,7 +287,7 @@ func (t TagSLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 		return decoder.PayloadConfig{
 			Fields: []decoder.FieldConfig{
 				{Name: "BufferLevel", Start: 0, Length: 2},
-				{Name: "Moving", Start: 2, Length: 1},
+				// {Name: "Moving", Start: 2, Length: 1},
 				{Name: "Latitude", Start: 3, Length: 4, Transform: func(v interface{}) interface{} {
 					return float64(v.(int)) / 1000000
 				}},
@@ -401,7 +400,13 @@ func (t TagSLv1Decoder) Decode(data string, port int16, devEui string) (interfac
 		return decodedData, nil, nil
 	}
 
-	statusData, err := parseStatusByte(data[*config.StatusByteIndex])
+	// convert hex payload to bytes
+	bytesData, err := helpers.HexStringToBytes(data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	statusData, err := parseStatusByte(bytesData[*config.StatusByteIndex])
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2,6 +2,7 @@ package tagsl
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -16,7 +17,6 @@ func TestDecode(t *testing.T) {
 			payload: "8002cdcd1300744f5e166018040b14341a",
 			port:    1,
 			expected: Port1Payload{
-				Moving:    false,
 				Latitude:  47.041811,
 				Longitude: 7.622494,
 				Altitude:  572.8,
@@ -29,18 +29,14 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			payload: "00",
-			port:    2,
-			expected: Port2Payload{
-				Moving: false,
-			},
+			payload:  "00",
+			port:     2,
+			expected: Port2Payload{},
 		},
 		{
-			payload: "01",
-			port:    2,
-			expected: Port2Payload{
-				Moving: true,
-			},
+			payload:  "01",
+			port:     2,
+			expected: Port2Payload{},
 		},
 		{
 			payload: "822f0101f052fab920feafd0e4158b38b9afe05994cb2f5cb2",
@@ -114,48 +110,44 @@ func TestDecode(t *testing.T) {
 			payload: "808c59c3c99fc0ad",
 			port:    5,
 			expected: Port5Payload{
-				Moving: false,
-				Mac1:   "8c59c3c99fc0",
-				Rssi1:  -83,
+				Mac1:  "8c59c3c99fc0",
+				Rssi1: -83,
 			},
 		},
 		{
 			payload: "80e0286d8a2742a1",
 			port:    5,
 			expected: Port5Payload{
-				Moving: false,
-				Mac1:   "e0286d8a2742",
-				Rssi1:  -95,
+				Mac1:  "e0286d8a2742",
+				Rssi1: -95,
 			},
 		},
 		{
 			payload: "001f3fd57cecb4f0b0140c96bbb2e0286d8a9478b8",
 			port:    5,
 			expected: Port5Payload{
-				Moving: false,
-				Mac1:   "1f3fd57cecb4",
-				Rssi1:  -16,
-				Mac2:   "b0140c96bbb2",
-				Rssi2:  -32,
-				Mac3:   "286d8a9478b8",
-				Rssi3:  0,
+				Mac1:  "1f3fd57cecb4",
+				Rssi1: -16,
+				Mac2:  "b0140c96bbb2",
+				Rssi2: -32,
+				Mac3:  "286d8a9478b8",
+				Rssi3: 0,
 			},
 		},
 		{
 			payload: "00e0286d8aabfca8e0286d8a9478c2726c9a74b58dab726cdac8b89dacf0b0140c96bbc8",
 			port:    5,
 			expected: Port5Payload{
-				Moving: false,
-				Mac1:   "e0286d8aabfc",
-				Rssi1:  -88,
-				Mac2:   "e0286d8a9478",
-				Rssi2:  -62,
-				Mac3:   "726c9a74b58d",
-				Rssi3:  -85,
-				Mac4:   "726cdac8b89d",
-				Rssi4:  -84,
-				Mac5:   "f0b0140c96bb",
-				Rssi5:  -56,
+				Mac1:  "e0286d8aabfc",
+				Rssi1: -88,
+				Mac2:  "e0286d8a9478",
+				Rssi2: -62,
+				Mac3:  "726c9a74b58d",
+				Rssi3: -85,
+				Mac4:  "726cdac8b89d",
+				Rssi4: -84,
+				Mac5:  "f0b0140c96bb",
+				Rssi5: -56,
 			},
 		},
 		{
@@ -177,7 +169,6 @@ func TestDecode(t *testing.T) {
 			port:    7,
 			expected: Port7Payload{
 				Timestamp: time.Date(2024, 9, 19, 11, 2, 19, 0, time.UTC),
-				Moving:    false,
 				Mac1:      "e0286d8aabfc",
 				Rssi1:     -69,
 				Mac2:      "ec6c9a74b58f",
@@ -211,7 +202,6 @@ func TestDecode(t *testing.T) {
 			payload: "0002d308b50082457f16eb66c4a5cd0ed3",
 			port:    10,
 			expected: Port10Payload{
-				Moving:    false,
 				Latitude:  47.384757,
 				Longitude: 8.537471,
 				Altitude:  586.7,
@@ -223,7 +213,6 @@ func TestDecode(t *testing.T) {
 			payload: "0002D30B070082491F11256718D9FE0EDE190505",
 			port:    10,
 			expected: Port10Payload{
-				Moving:     false,
 				Latitude:   47.385351,
 				Longitude:  8.538399,
 				Altitude:   438.9,
@@ -254,7 +243,6 @@ func TestDecode(t *testing.T) {
 			payload: "0002d30c9300824c87117966c45dcd0f8118e0286d8aabfca9f0b0140c96bbc8726c9a74b58da8e0286d8a9478bf",
 			port:    50,
 			expected: Port50Payload{
-				Moving:    false,
 				Latitude:  47.385747,
 				Longitude: 8.539271,
 				Altitude:  447.3,
@@ -275,7 +263,6 @@ func TestDecode(t *testing.T) {
 			payload: "0102d30b2a0082499c10ee66c496900ed34af0b0140c96bbb3e0286d8a9478c3fc848e9b5571c2",
 			port:    50,
 			expected: Port50Payload{
-				Moving:    true,
 				Latitude:  47.385386,
 				Longitude: 8.538524,
 				Altitude:  433.4,
@@ -294,7 +281,6 @@ func TestDecode(t *testing.T) {
 			payload: "0002D30BA000824ACE1122671B983E0EEA340B06726C9A74B58DB1FCF528F8634FB552A8DB7BD6B5B9E0286D8AABFCBC",
 			port:    51,
 			expected: Port51Payload{
-				Moving:     false,
 				Latitude:   47.385504,
 				Longitude:  8.53883,
 				Altitude:   438.6,
@@ -318,7 +304,6 @@ func TestDecode(t *testing.T) {
 			port:    105,
 			expected: Port105Payload{
 				BufferLevel: 1,
-				Moving:      false,
 				Timestamp:   time.Date(2024, 8, 20, 14, 18, 34, 0, time.UTC),
 				Mac1:        "e0286d8aabfc",
 				Rssi1:       -79,
@@ -337,7 +322,6 @@ func TestDecode(t *testing.T) {
 			port:    105,
 			expected: Port105Payload{
 				BufferLevel: 257,
-				Moving:      false,
 				Timestamp:   time.Date(2024, 8, 20, 14, 18, 34, 0, time.UTC),
 				Mac1:        "e0286d8aabfc",
 				Rssi1:       -79,
@@ -356,7 +340,6 @@ func TestDecode(t *testing.T) {
 			port:    105,
 			expected: Port105Payload{
 				BufferLevel: 19,
-				Moving:      false,
 				Timestamp:   time.Date(2024, 9, 21, 2, 28, 29, 0, time.UTC),
 				Mac1:        "c4eb438ddde2",
 				Rssi1:       -91,
@@ -377,7 +360,6 @@ func TestDecode(t *testing.T) {
 			port:    110,
 			expected: Port110Payload{
 				BufferLevel: 2,
-				Moving:      false,
 				Latitude:    47.385006,
 				Longitude:   8.538053,
 				Altitude:    440.9,
@@ -390,7 +372,6 @@ func TestDecode(t *testing.T) {
 			port:    110,
 			expected: Port110Payload{
 				BufferLevel: 258,
-				Moving:      false,
 				Latitude:    47.385006,
 				Longitude:   8.538053,
 				Altitude:    440.9,
@@ -403,7 +384,6 @@ func TestDecode(t *testing.T) {
 			port:    110,
 			expected: Port110Payload{
 				BufferLevel: 4,
-				Moving:      false,
 				Latitude:    47.385484,
 				Longitude:   8.538677,
 				Altitude:    438.6,
@@ -416,7 +396,6 @@ func TestDecode(t *testing.T) {
 			port:    150,
 			expected: Port150Payload{
 				BufferLevel: 2,
-				Moving:      false,
 				Latitude:    47.385747,
 				Longitude:   8.539271,
 				Altitude:    447.3,
@@ -438,7 +417,6 @@ func TestDecode(t *testing.T) {
 			port:    150,
 			expected: Port150Payload{
 				BufferLevel: 258,
-				Moving:      false,
 				Latitude:    47.385747,
 				Longitude:   8.539271,
 				Altitude:    447.3,
@@ -460,7 +438,6 @@ func TestDecode(t *testing.T) {
 			port:    150,
 			expected: Port150Payload{
 				BufferLevel: 0,
-				Moving:      true,
 				Latitude:    47.38524,
 				Longitude:   8.538294,
 				Altitude:    452.4,
@@ -482,7 +459,6 @@ func TestDecode(t *testing.T) {
 			port:    151,
 			expected: Port151Payload{
 				BufferLevel: 0,
-				Moving:      false,
 				Latitude:    47.385383,
 				Longitude:   8.53804,
 				Altitude:    488.2,
@@ -627,7 +603,6 @@ func TestFullDecode(t *testing.T) {
 		{
 			payload: "8002cdcd1300744f5e166018040b14341a",
 			expectedData: Port1Payload{
-				Moving:    false,
 				Latitude:  47.041811,
 				Longitude: 7.622494,
 				Altitude:  572.8,
@@ -650,7 +625,6 @@ func TestFullDecode(t *testing.T) {
 			payload: "66ec04bb00e0286d8aabfcbbec6c9a74b58fb2726c9a74b58db1e0286d8a9478cbf0b0140c96bbd2260122180d42ad",
 			expectedData: Port7Payload{
 				Timestamp: time.Date(2024, 9, 19, 11, 2, 19, 0, time.UTC),
-				Moving:    false,
 				Mac1:      "e0286d8aabfc",
 				Rssi1:     -69,
 				Mac2:      "ec6c9a74b58f",
@@ -675,21 +649,20 @@ func TestFullDecode(t *testing.T) {
 		{
 			payload: "0c24651155ce55b8602232e20f52b0ac8ba91fedaaa5603197f93781a90aecdafa5fe8bc02ecdafa5fe8bd8c59c3c960f0a5",
 			expectedData: Port5Payload{
-				Moving: false,
-				Mac1:   "24651155ce55",
-				Rssi1:  -72,
-				Mac2:   "602232e20f52",
-				Rssi2:  -80,
-				Mac3:   "ac8ba91fedaa",
-				Rssi3:  -91,
-				Mac4:   "603197f93781",
-				Rssi4:  -87,
-				Mac5:   "0aecdafa5fe8",
-				Rssi5:  -68,
-				Mac6:   "02ecdafa5fe8",
-				Rssi6:  -67,
-				Mac7:   "8c59c3c960f0",
-				Rssi7:  -91,
+				Mac1:  "24651155ce55",
+				Rssi1: -72,
+				Mac2:  "602232e20f52",
+				Rssi2: -80,
+				Mac3:  "ac8ba91fedaa",
+				Rssi3: -91,
+				Mac4:  "603197f93781",
+				Rssi4: -87,
+				Mac5:  "0aecdafa5fe8",
+				Rssi5: -68,
+				Mac6:  "02ecdafa5fe8",
+				Rssi6: -67,
+				Mac7:  "8c59c3c960f0",
+				Rssi7: -91,
 			},
 			expectedStatus: &Status{
 				DutyCycle:           false,
@@ -698,6 +671,50 @@ func TestFullDecode(t *testing.T) {
 				Moving:              false,
 			},
 			port: 5,
+		},
+		{
+			payload: "00430102d43ffa00772d870ea367250ef60eda",
+			expectedData: Port110Payload{
+				BufferLevel: 67,
+				Latitude:    47.464442,
+				Longitude:   7.810439,
+				Altitude:    374.7,
+				Timestamp:   time.Date(2024, 11, 1, 17, 25, 10, 0, time.UTC),
+				Battery:     3.802,
+			},
+			expectedStatus: &Status{
+				DutyCycle:           false,
+				ConfigChangeId:      0,
+				ConfigChangeSuccess: false,
+				Moving:              true,
+			},
+			port: 110,
+		},
+		{
+			payload: "0028672658500172a741b1e238b572a741b1e08bb03498b5c583e2b172a741b1e0cda772a741beed4cc472a741beef53b772a741b1dd0000",
+			expectedData: Port105Payload{
+				BufferLevel: 40,
+				Mac1:        "72a741b1e238",
+				Rssi1:       -75,
+				Mac2:        "72a741b1e08b",
+				Rssi2:       -80,
+				Mac3:        "3498b5c583e2",
+				Rssi3:       -79,
+				Mac4:        "72a741b1e0cd",
+				Rssi4:       -89,
+				Mac5:        "72a741beed4c",
+				Rssi5:       -60,
+				Mac6:        "72a741beef53",
+				Rssi6:       -73,
+				Timestamp:   time.Date(2024, 11, 2, 16, 50, 24, 0, time.UTC),
+			},
+			expectedStatus: &Status{
+				DutyCycle:           false,
+				ConfigChangeId:      0,
+				ConfigChangeSuccess: false,
+				Moving:              true,
+			},
+			port: 105,
 		},
 	}
 
@@ -717,6 +734,11 @@ func TestFullDecode(t *testing.T) {
 			}
 			if status == nil && test.expectedStatus != nil {
 				t.Errorf("expected status: %v, got: nil", test.expectedStatus)
+			}
+
+			// check if status is equal to expected status using reflect.DeepEqual
+			if reflect.DeepEqual(status, *test.expectedStatus) == false {
+				t.Errorf("expected status: %v, got: %v", *test.expectedStatus, status)
 			}
 		})
 	}

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -193,6 +193,21 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
+			payload: "012c141e9c455738304543434343460078012c01a8c0",
+			port:    8,
+			expected: Port8Payload{
+				ScanInterval:                          300,
+				ScanTime:                              20,
+				MaxBeacons:                            30,
+				MinRssiValue:                          -100,
+				AdvertisingFilter:                     "4048812220199682886",
+				AccelerometerTriggerHoldTimer:         120,
+				AccelerometerThreshold:                300,
+				BLECurrentConfigurationUplinkInterval: 43200,
+				ScanMode:                              1,
+			},
+		},
+		{
 			payload: "0002d308b50082457f16eb66c4a5cd0ed3",
 			port:    10,
 			expected: Port10Payload{

--- a/pkg/decoder/tagsl/v1/port1.go
+++ b/pkg/decoder/tagsl/v1/port1.go
@@ -16,7 +16,6 @@ package tagsl
 // +------+------+-------------------------------------------+------------------------+
 
 type Port1Payload struct {
-	Moving    bool    `json:"moving"`
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
 	Altitude  float64 `json:"altitude"`

--- a/pkg/decoder/tagsl/v1/port10.go
+++ b/pkg/decoder/tagsl/v1/port10.go
@@ -17,7 +17,6 @@ import "time"
 // +------+------+-------------------------------------------+------------------------+
 
 type Port10Payload struct {
-	Moving     bool      `json:"moving"`
 	Latitude   float64   `json:"latitude"`
 	Longitude  float64   `json:"longitude"`
 	Altitude   float64   `json:"altitude"`

--- a/pkg/decoder/tagsl/v1/port105.go
+++ b/pkg/decoder/tagsl/v1/port105.go
@@ -18,7 +18,6 @@ import "time"
 type Port105Payload struct {
 	BufferLevel uint16    `json:"bufferLevel"`
 	Timestamp   time.Time `json:"timestamp"`
-	Moving      bool      `json:"moving"`
 	Mac1        string    `json:"mac1"`
 	Rssi1       int8      `json:"rssi1"`
 	Mac2        string    `json:"mac2"`

--- a/pkg/decoder/tagsl/v1/port110.go
+++ b/pkg/decoder/tagsl/v1/port110.go
@@ -16,7 +16,6 @@ import "time"
 
 type Port110Payload struct {
 	BufferLevel uint16    `json:"bufferLevel"`
-	Moving      bool      `json:"moving"`
 	Latitude    float64   `json:"latitude"`
 	Longitude   float64   `json:"longitude"`
 	Altitude    float64   `json:"altitude"`

--- a/pkg/decoder/tagsl/v1/port150.go
+++ b/pkg/decoder/tagsl/v1/port150.go
@@ -23,7 +23,6 @@ import "time"
 // Timestamp for the Wi-Fi scanning is TSGNSS – TTF + 10 seconds.
 type Port150Payload struct {
 	BufferLevel uint16    `json:"bufferLevel"`
-	Moving      bool      `json:"moving"`
 	Latitude    float64   `json:"latitude"`
 	Longitude   float64   `json:"longitude"`
 	Altitude    float64   `json:"altitude"`

--- a/pkg/decoder/tagsl/v1/port151.go
+++ b/pkg/decoder/tagsl/v1/port151.go
@@ -25,7 +25,6 @@ import "time"
 // Timestamp for the Wi-Fi scanning is TSGNSS – TTF + 10 seconds.
 type Port151Payload struct {
 	BufferLevel uint16    `json:"bufferLevel"`
-	Moving      bool      `json:"moving"`
 	Latitude    float64   `json:"latitude"`
 	Longitude   float64   `json:"longitude"`
 	Altitude    float64   `json:"altitude"`

--- a/pkg/decoder/tagsl/v1/port2.go
+++ b/pkg/decoder/tagsl/v1/port2.go
@@ -7,5 +7,4 @@ package tagsl
 // +------+------+-------------------------------------------+--------+
 
 type Port2Payload struct {
-	Moving bool `json:"moving"`
 }

--- a/pkg/decoder/tagsl/v1/port5.go
+++ b/pkg/decoder/tagsl/v1/port5.go
@@ -12,19 +12,18 @@ package tagsl
 // +------+------+-------------------------------------------+-----------+
 
 type Port5Payload struct {
-	Moving bool   `json:"moving"`
-	Mac1   string `json:"mac1"`
-	Rssi1  int8   `json:"rssi1"`
-	Mac2   string `json:"mac2"`
-	Rssi2  int8   `json:"rssi2"`
-	Mac3   string `json:"mac3"`
-	Rssi3  int8   `json:"rssi3"`
-	Mac4   string `json:"mac4"`
-	Rssi4  int8   `json:"rssi4"`
-	Mac5   string `json:"mac5"`
-	Rssi5  int8   `json:"rssi5"`
-	Mac6   string `json:"mac6"`
-	Rssi6  int8   `json:"rssi6"`
-	Mac7   string `json:"mac7"`
-	Rssi7  int8   `json:"rssi7"`
+	Mac1  string `json:"mac1"`
+	Rssi1 int8   `json:"rssi1"`
+	Mac2  string `json:"mac2"`
+	Rssi2 int8   `json:"rssi2"`
+	Mac3  string `json:"mac3"`
+	Rssi3 int8   `json:"rssi3"`
+	Mac4  string `json:"mac4"`
+	Rssi4 int8   `json:"rssi4"`
+	Mac5  string `json:"mac5"`
+	Rssi5 int8   `json:"rssi5"`
+	Mac6  string `json:"mac6"`
+	Rssi6 int8   `json:"rssi6"`
+	Mac7  string `json:"mac7"`
+	Rssi7 int8   `json:"rssi7"`
 }

--- a/pkg/decoder/tagsl/v1/port50.go
+++ b/pkg/decoder/tagsl/v1/port50.go
@@ -21,7 +21,6 @@ import "time"
 
 // Timestamp for the Wi-Fi scanning is TSGNSS – TTF + 10 seconds.
 type Port50Payload struct {
-	Moving    bool      `json:"moving"`
 	Latitude  float64   `json:"latitude"`
 	Longitude float64   `json:"longitude"`
 	Altitude  float64   `json:"altitude"`

--- a/pkg/decoder/tagsl/v1/port51.go
+++ b/pkg/decoder/tagsl/v1/port51.go
@@ -23,7 +23,6 @@ import "time"
 
 // Timestamp for the Wi-Fi scanning is TSGNSS – TTF + 10 seconds.
 type Port51Payload struct {
-	Moving     bool      `json:"moving"`
 	Latitude   float64   `json:"latitude"`
 	Longitude  float64   `json:"longitude"`
 	Altitude   float64   `json:"altitude"`

--- a/pkg/decoder/tagsl/v1/port7.go
+++ b/pkg/decoder/tagsl/v1/port7.go
@@ -23,7 +23,6 @@ import "time"
 
 type Port7Payload struct {
 	Timestamp time.Time `json:"timestamp"`
-	Moving    bool      `json:"moving"`
 	Mac1      string    `json:"mac1"`
 	Rssi1     int8      `json:"rssi1"`
 	Mac2      string    `json:"mac2"`

--- a/pkg/decoder/tagsl/v1/port8.go
+++ b/pkg/decoder/tagsl/v1/port8.go
@@ -1,0 +1,26 @@
+package tagsl
+
+// | Byte   | Size | Description                                 | Format                                             |
+// |--------|------|--------------------------------------------|-----------------------------------------------------|
+// | 0-1    | 2    | Scan interval                              | uint16, s                                           |
+// | 2      | 1    | Scan time                                  | uint8, s [0..180]                                   |
+// | 3      | 1    | Max beacons                                | uint8                                               |
+// | 4      | 1    | Min. Rssi value                            | int8                                                |
+// | 5-14   | 10   | Advertising name/eddystone namespace filter | 10 x ASCII or 10 x uint8                           |
+// | 15-16  | 2    | Accelerometer trigger hold timer           | uint16, s                                           |
+// | 17-18  | 2    | Accelerometer threshold                    | uint16, mg                                          |
+// | 19     | 1    | Scan mode                                  | 0 - no filter; 1 - advertised name filter;          |
+// | 		|	   |											| 2 - eddystone namespace filter                      |
+// | 20-21  | 2    | BLE current configuration uplink interval  | uint16, s                                           |
+
+type Port8Payload struct {
+	ScanInterval                          uint16 `json:"scanInterval"`
+	ScanTime                              uint8  `json:"scanTime"`
+	MaxBeacons                            uint8  `json:"maxBeacons"`
+	MinRssiValue                          int8   `json:"minRssiValue"`
+	AdvertisingFilter                     string `json:"advertisingFilter"`
+	AccelerometerTriggerHoldTimer         uint16 `json:"accelerometerTriggerHoldTimer"`
+	AccelerometerThreshold                uint16 `json:"accelerometerThreshold"`
+	ScanMode                              uint8  `json:"scanMode"`
+	BLECurrentConfigurationUplinkInterval uint16 `json:"bleCurrentConfigurationUplinkInterval"`
+}


### PR DESCRIPTION
This PR addresses a bug in processing the `moving` flag, ensuring it is correctly interpreted as a hexadecimal string. Previously, the `moving` flag's value was incorrectly processed because it was not handled as a hex string, leading to potential misinterpretations of its state.

Additionally, this PR modifies how the `moving` attribute is accessed. Rather than being directly available in the payloads, the `moving` attribute is now consistently nested within the `metadata` object as `metadata.moving`. This update standardizes attribute access across all payloads, promoting consistency and simplifying downstream data handling.

### Summary of Changes:
- **Hex String Handling**: Ensures the `moving` flag is correctly parsed as a hexadecimal string.
- **Consistent Attribute Access**: Standardizes `moving` under `metadata.moving` across all payloads.

