### PR TITLE
Bugfix/logger init

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,10 +84,6 @@ A CLI tool to help decode @truvami payloads.`,
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		logger.NewLogger()
-		defer logger.Sync()
-
-		logger.Logger.Error("error while executing command", zap.Error(err))
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,9 @@ A CLI tool to help decode @truvami payloads.`,
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		logger.NewLogger()
+		defer logger.Sync()
+
 		logger.Logger.Error("error while executing command", zap.Error(err))
 		os.Exit(1)
 	}


### PR DESCRIPTION
Added missing logger initialization in cases where no arguments are provided to the decoder, which caused nil pointer panic.