### PR TITLE
fix(tagsl): port 4 now accepts optional size fields

### DIFF
--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -107,6 +107,8 @@ func (t TagSLv1Decoder) getConfig(port int16) (decoder.PayloadConfig, error) {
 				{Name: "HardwareVersionType", Start: 22, Length: 1},
 				{Name: "HardwareVersionRevision", Start: 23, Length: 1},
 				{Name: "BatteryKeepAliveMessageInterval", Start: 24, Length: 4},
+				{Name: "BatchSize", Start: 28, Length: 2, Optional: true},
+				{Name: "BufferSize", Start: 30, Length: 2, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port4Payload{}),
 		}, nil

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -173,7 +173,7 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			payload:        "0000003c0000012c000151800078012c05dc02020100010200005460deadbeef",
+			payload:        "0000003c0000012c000151800078012c05dc02020100010200005460000a1000",
 			port:           4,
 			autoPadding:    false,
 			skipValidation: true,
@@ -191,6 +191,8 @@ func TestDecode(t *testing.T) {
 				HardwareVersionType:             1,
 				HardwareVersionRevision:         2,
 				BatteryKeepAliveMessageInterval: 21600,
+				BatchSize:                       10,
+				BufferSize:                      4096,
 			},
 		},
 		{

--- a/pkg/decoder/tagsl/v1/port4.go
+++ b/pkg/decoder/tagsl/v1/port4.go
@@ -16,18 +16,18 @@ package tagsl
 // +-------+------+-------------------------------------------+------------+
 
 type Port4Payload struct {
-	LocalizationIntervalWhileMoving uint32 `json:"localizationIntervalWhileMoving"`
-	LocalizationIntervalWhileSteady uint32 `json:"localizationIntervalWhileSteady"`
-	HeartbeatInterval               uint32 `json:"heartbeatInterval"`
-	GPSTimeoutWhileWaitingForFix    uint16 `json:"gpsTimeoutWhileWaitingForFix"`
-	AccelerometerWakeupThreshold    uint16 `json:"accelerometerWakeupThreshold"`
-	AccelerometerDelay              uint16 `json:"accelerometerDelay"`
+	LocalizationIntervalWhileMoving uint32 `json:"localizationIntervalWhileMoving" validate:"gte=60,lte=86400"`
+	LocalizationIntervalWhileSteady uint32 `json:"localizationIntervalWhileSteady" validate:"gte=120,lte=86400"`
+	HeartbeatInterval               uint32 `json:"heartbeatInterval" validate:"gte=300,lte=604800"`
+	GPSTimeoutWhileWaitingForFix    uint16 `json:"gpsTimeoutWhileWaitingForFix" validate:"gte=60,lte=86400"`
+	AccelerometerWakeupThreshold    uint16 `json:"accelerometerWakeupThreshold" validate:"gte=10,lte=8000"`
+	AccelerometerDelay              uint16 `json:"accelerometerDelay" validate:"gte=1000,lte=10000"`
 	DeviceState                     uint8  `json:"deviceState"`
 	FirmwareVersionMajor            uint8  `json:"firmwareVersionMajor"`
 	FirmwareVersionMinor            uint8  `json:"firmwareVersionMinor"`
 	FirmwareVersionPatch            uint8  `json:"firmwareVersionPatch"`
 	HardwareVersionType             uint8  `json:"hardwareVersionType"`
-	HardwareVersionRevision         uint8  `json:"hardwareVersionRevision"`
+	HardwareVersionRevision         uint8  `json:"hardwareVersionRevision" validate:"gte=300,lte=604800"`
 	BatteryKeepAliveMessageInterval uint32 `json:"batteryKeepAliveMessageInterval"`
 	BatchSize                       uint16 `json:"batchSize" validate:"lte=50"`
 	BufferSize                      uint16 `json:"bufferSize" validate:"gte=128,lte=8128"`

--- a/pkg/decoder/tagsl/v1/port4.go
+++ b/pkg/decoder/tagsl/v1/port4.go
@@ -27,8 +27,8 @@ type Port4Payload struct {
 	FirmwareVersionMinor            uint8  `json:"firmwareVersionMinor"`
 	FirmwareVersionPatch            uint8  `json:"firmwareVersionPatch"`
 	HardwareVersionType             uint8  `json:"hardwareVersionType"`
-	HardwareVersionRevision         uint8  `json:"hardwareVersionRevision" validate:"gte=300,lte=604800"`
-	BatteryKeepAliveMessageInterval uint32 `json:"batteryKeepAliveMessageInterval"`
+	HardwareVersionRevision         uint8  `json:"hardwareVersionRevision"`
+	BatteryKeepAliveMessageInterval uint32 `json:"batteryKeepAliveMessageInterval" validate:"gte=300,lte=604800"`
 	BatchSize                       uint16 `json:"batchSize" validate:"lte=50"`
 	BufferSize                      uint16 `json:"bufferSize" validate:"gte=128,lte=8128"`
 }

--- a/pkg/decoder/tagsl/v1/port4.go
+++ b/pkg/decoder/tagsl/v1/port4.go
@@ -29,4 +29,6 @@ type Port4Payload struct {
 	HardwareVersionType             uint8  `json:"hardwareVersionType"`
 	HardwareVersionRevision         uint8  `json:"hardwareVersionRevision"`
 	BatteryKeepAliveMessageInterval uint32 `json:"batteryKeepAliveMessageInterval"`
+	BatchSize                       uint16 `json:"batchSize" validate:"lte=50"`
+	BufferSize                      uint16 `json:"bufferSize" validate:"gte=128,lte=8128"`
 }


### PR DESCRIPTION
I added batch size and buffer size as optional fields to the port 4 payload. 
This leads to the max payload length to be 32 bytes and min payload length 28 bytes. 
Also, I could not resist adding some additional validation. 