### PR TITLE
Extended `Decoder` interface.

### DIFF
--- a/examples/advanced_tag_s_l/main.go
+++ b/examples/advanced_tag_s_l/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+
+	"github.com/truvami/decoder/pkg/decoder/tagsl/v1"
+)
+
+func main() {
+	log.Println("initializing tag S / L decoder...")
+	d := tagsl.NewTagSLv1Decoder()
+
+	// decode data
+	log.Println("decoding data...")
+	location, _, err := d.DecodePosition("0002c420ff005ed85a12b4180719142607", 1, "")
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("latitude: %f, longitude: %f, altitude: %f\n", location.GetLatitude(), location.GetLongitude(), *location.GetAltitude())
+}

--- a/examples/advanced_tag_s_l/main_test.go
+++ b/examples/advanced_tag_s_l/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	// Create a buffer to capture the output
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	// Run the main function
+	main()
+
+	// Check if the expected output is present in the buffer
+	expectedOutput := `46.407935`
+	if !strings.Contains(buf.String(), expectedOutput) {
+		t.Errorf("expected output %q not found", expectedOutput)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvami/decoder
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/go-playground/validator v9.31.0+incompatible

--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -1,5 +1,9 @@
 package decoder
 
+import "github.com/truvami/decoder/pkg/common"
+
 type Decoder interface {
 	Decode(string, int16, string) (interface{}, interface{}, error)
+	DecodePosition(string, int16, string) (common.Position, interface{}, error)
+	DecodeWifi(string, int16, string) (common.WifiLocation, interface{}, error)
 }

--- a/pkg/decoder/nomadxl/v1/decoder.go
+++ b/pkg/decoder/nomadxl/v1/decoder.go
@@ -15,6 +15,33 @@ type NomadXLv1Decoder struct {
 	skipValidation bool
 }
 
+// DecodeWifi implements decoder.Decoder.
+func (t *NomadXLv1Decoder) DecodeWifi(string, int16, string) (common.WifiLocation, interface{}, error) {
+	panic("unimplemented")
+}
+
+// DecodePosition implements decoder.Decoder.
+func (t *NomadXLv1Decoder) DecodePosition(data string, port int16, devEui string) (common.Position, interface{}, error) {
+	config, err := t.getConfig(port)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if t.autoPadding {
+		data = common.HexNullPad(&data, &config)
+	}
+
+	if !t.skipValidation {
+		err := common.ValidateLength(&data, &config)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	decodedData, err := common.Parse[common.Position](data, &config)
+	return decodedData, nil, err
+}
+
 func NewNomadXLv1Decoder(options ...Option) decoder.Decoder {
 	nomadXLv1Decoder := &NomadXLv1Decoder{}
 
@@ -108,6 +135,6 @@ func (t NomadXLv1Decoder) Decode(data string, port int16, devEui string) (interf
 		}
 	}
 
-	decodedData, err := common.Parse(data, &config)
+	decodedData, err := common.Parse[interface{}](data, &config)
 	return decodedData, nil, err
 }

--- a/pkg/decoder/nomadxs/v1/decoder.go
+++ b/pkg/decoder/nomadxs/v1/decoder.go
@@ -15,6 +15,33 @@ type NomadXSv1Decoder struct {
 	skipValidation bool
 }
 
+// DecodeWifi implements decoder.Decoder.
+func (t *NomadXSv1Decoder) DecodeWifi(string, int16, string) (common.WifiLocation, interface{}, error) {
+	panic("unimplemented")
+}
+
+// DecodePosition implements decoder.Decoder.
+func (t *NomadXSv1Decoder) DecodePosition(data string, port int16, devEui string) (common.Position, interface{}, error) {
+	config, err := t.getConfig(port)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if t.autoPadding {
+		data = common.HexNullPad(&data, &config)
+	}
+
+	if !t.skipValidation {
+		err := common.ValidateLength(&data, &config)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	decodedData, err := common.Parse[common.Position](data, &config)
+	return decodedData, nil, err
+}
+
 func NewNomadXSv1Decoder(options ...Option) decoder.Decoder {
 	nomadXSv1Decoder := &NomadXSv1Decoder{}
 
@@ -145,6 +172,6 @@ func (t NomadXSv1Decoder) Decode(data string, port int16, devEui string) (interf
 		}
 	}
 
-	decodedData, err := common.Parse(data, &config)
+	decodedData, err := common.Parse[interface{}](data, &config)
 	return decodedData, nil, err
 }

--- a/pkg/decoder/nomadxs/v1/port1.go
+++ b/pkg/decoder/nomadxs/v1/port1.go
@@ -1,5 +1,12 @@
 package nomadxs
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
+
 // +-------+------+-------------------------------------------+------------------------+
 // | Byte  | Size | Description                               | Format                 |
 // +-------+------+-------------------------------------------+------------------------+
@@ -52,4 +59,42 @@ type Port1Payload struct {
 	MagnetometerXAxis  float32 `json:"magnetometerXAxis"`
 	MagnetometerYAxis  float32 `json:"magnetometerYAxis"`
 	MagnetometerZAxis  float32 `json:"magnetometerZAxis"`
+}
+
+var _ common.Position = &Port1Payload{}
+
+func (p Port1Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port1Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port1Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port1Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port1Payload) GetCapturedAt() *time.Time {
+	capturedAt, err := time.Parse(time.RFC3339,
+		fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02dZ",
+			int(p.Year)+2000,
+			p.Month,
+			p.Day,
+			p.Hour,
+			p.Minute,
+			p.Second,
+		))
+	if err != nil {
+		return nil
+	}
+	return &capturedAt
+}
+
+func (p Port1Payload) GetBuffered() bool {
+	return false
 }

--- a/pkg/decoder/nomadxs/v1/port1_test.go
+++ b/pkg/decoder/nomadxs/v1/port1_test.go
@@ -1,0 +1,59 @@
+package nomadxs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetCapturedAt(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  Port1Payload
+		expected *time.Time
+	}{
+		{
+			name: "valid date and time",
+			payload: Port1Payload{
+				Year:   21,
+				Month:  10,
+				Day:    5,
+				Hour:   14,
+				Minute: 30,
+				Second: 45,
+			},
+			expected: func() *time.Time {
+				t, _ := time.Parse(time.RFC3339, "2021-10-05T14:30:45Z")
+				return &t
+			}(),
+		},
+		{
+			name: "invalid date",
+			payload: Port1Payload{
+				Year:   21,
+				Month:  13,
+				Day:    32,
+				Hour:   25,
+				Minute: 61,
+				Second: 61,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.payload.GetCapturedAt()
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("expected %v, got nil", tt.expected)
+				} else if !result.Equal(*tt.expected) {
+					t.Errorf("expected %v, got %v", tt.expected, result)
+				}
+			}
+		})
+	}
+}

--- a/pkg/decoder/tagsl/v1/port1.go
+++ b/pkg/decoder/tagsl/v1/port1.go
@@ -1,5 +1,12 @@
 package tagsl
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
+
 // +------+------+-------------------------------------------+------------------------+
 // | Byte | Size | Description                               | Format                 |
 // +------+------+-------------------------------------------+------------------------+
@@ -25,4 +32,42 @@ type Port1Payload struct {
 	Hour      uint8   `json:"hour" validate:"gte=0,lte=23"`
 	Minute    uint8   `json:"minute" validate:"gte=0,lte=59"`
 	Second    uint8   `json:"second" validate:"gte=0,lte=59"`
+}
+
+var _ common.Position = &Port1Payload{}
+
+func (p Port1Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port1Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port1Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port1Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port1Payload) GetCapturedAt() *time.Time {
+	capturedAt, err := time.Parse(time.RFC3339,
+		fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02dZ",
+			int(p.Year)+2000,
+			p.Month,
+			p.Day,
+			p.Hour,
+			p.Minute,
+			p.Second,
+		))
+	if err != nil {
+		return nil
+	}
+	return &capturedAt
+}
+
+func (p Port1Payload) GetBuffered() bool {
+	return false
 }

--- a/pkg/decoder/tagsl/v1/port10.go
+++ b/pkg/decoder/tagsl/v1/port10.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +------+------+-------------------------------------------+------------------------+
 // | Byte | Size | Description                               | Format                 |
@@ -25,4 +29,30 @@ type Port10Payload struct {
 	TTF        float64   `json:"ttf"`
 	PDOP       float64   `json:"pdop"`
 	Satellites uint8     `json:"satellites" validate:"gte=3,lte=27"`
+}
+
+var _ common.Position = &Port10Payload{}
+
+func (p Port10Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port10Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port10Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port10Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port10Payload) GetCapturedAt() *time.Time {
+	return &p.Timestamp
+}
+
+func (p Port10Payload) GetBuffered() bool {
+	return false
 }

--- a/pkg/decoder/tagsl/v1/port105.go
+++ b/pkg/decoder/tagsl/v1/port105.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +-------+------+-------------------------------------------+-----------+
 // | Byte  | Size | Description                               | Format    |
@@ -30,4 +34,19 @@ type Port105Payload struct {
 	Rssi5       int8      `json:"rssi5"`
 	Mac6        string    `json:"mac6"`
 	Rssi6       int8      `json:"rssi6"`
+}
+
+var _ common.WifiLocation = &Port105Payload{}
+
+func (p Port105Payload) GetAccessPoints() []common.WifiAccessPoint {
+	var accessPoints []common.WifiAccessPoint
+
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac1, p.Rssi1)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac2, p.Rssi2)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac3, p.Rssi3)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac4, p.Rssi4)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac5, p.Rssi5)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac6, p.Rssi6)
+
+	return accessPoints
 }

--- a/pkg/decoder/tagsl/v1/port110.go
+++ b/pkg/decoder/tagsl/v1/port110.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +-------+------+-------------------------------------------+------------------------+
 // | Byte  | Size | Description                               | Format                 |
@@ -21,4 +25,30 @@ type Port110Payload struct {
 	Altitude    float64   `json:"altitude"`
 	Timestamp   time.Time `json:"timestamp"`
 	Battery     float64   `json:"battery" validate:"gte=1,lte=5"`
+}
+
+var _ common.Position = &Port110Payload{}
+
+func (p Port110Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port110Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port110Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port110Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port110Payload) GetCapturedAt() *time.Time {
+	return &p.Timestamp
+}
+
+func (p Port110Payload) GetBuffered() bool {
+	return true
 }

--- a/pkg/decoder/tagsl/v1/port150.go
+++ b/pkg/decoder/tagsl/v1/port150.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +------+------+-------------------------------------------+------------------------+
 // | Byte | Size | Description                               | Format                 |
@@ -43,4 +47,46 @@ type Port150Payload struct {
 	Rssi6       int8      `json:"rssi6"`
 	Mac7        string    `json:"mac7"`
 	Rssi7       int8      `json:"rssi7"`
+}
+
+var _ common.Position = &Port150Payload{}
+
+func (p Port150Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port150Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port150Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port150Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port150Payload) GetCapturedAt() *time.Time {
+	return &p.Timestamp
+}
+
+func (p Port150Payload) GetBuffered() bool {
+	return true
+}
+
+var _ common.WifiLocation = &Port150Payload{}
+
+func (p Port150Payload) GetAccessPoints() []common.WifiAccessPoint {
+	var accessPoints []common.WifiAccessPoint
+
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac1, p.Rssi1)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac2, p.Rssi2)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac3, p.Rssi3)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac4, p.Rssi4)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac5, p.Rssi5)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac6, p.Rssi6)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac7, p.Rssi7)
+
+	return accessPoints
 }

--- a/pkg/decoder/tagsl/v1/port151.go
+++ b/pkg/decoder/tagsl/v1/port151.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +------+------+-------------------------------------------+------------------------+
 // | Byte | Size | Description                               | Format                 |
@@ -47,4 +51,46 @@ type Port151Payload struct {
 	Rssi6       int8      `json:"rssi6"`
 	Mac7        string    `json:"mac7"`
 	Rssi7       int8      `json:"rssi7"`
+}
+
+var _ common.Position = &Port151Payload{}
+
+func (p Port151Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port151Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port151Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port151Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port151Payload) GetCapturedAt() *time.Time {
+	return &p.Timestamp
+}
+
+func (p Port151Payload) GetBuffered() bool {
+	return true
+}
+
+var _ common.WifiLocation = &Port151Payload{}
+
+func (p Port151Payload) GetAccessPoints() []common.WifiAccessPoint {
+	var accessPoints []common.WifiAccessPoint
+
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac1, p.Rssi1)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac2, p.Rssi2)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac3, p.Rssi3)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac4, p.Rssi4)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac5, p.Rssi5)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac6, p.Rssi6)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac7, p.Rssi7)
+
+	return accessPoints
 }

--- a/pkg/decoder/tagsl/v1/port1_test.go
+++ b/pkg/decoder/tagsl/v1/port1_test.go
@@ -1,0 +1,59 @@
+package tagsl
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetCapturedAt(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  Port1Payload
+		expected *time.Time
+	}{
+		{
+			name: "valid date and time",
+			payload: Port1Payload{
+				Year:   21,
+				Month:  10,
+				Day:    5,
+				Hour:   14,
+				Minute: 30,
+				Second: 45,
+			},
+			expected: func() *time.Time {
+				t, _ := time.Parse(time.RFC3339, "2021-10-05T14:30:45Z")
+				return &t
+			}(),
+		},
+		{
+			name: "invalid date",
+			payload: Port1Payload{
+				Year:   21,
+				Month:  13,
+				Day:    32,
+				Hour:   25,
+				Minute: 61,
+				Second: 61,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.payload.GetCapturedAt()
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("expected %v, got nil", tt.expected)
+				} else if !result.Equal(*tt.expected) {
+					t.Errorf("expected %v, got %v", tt.expected, result)
+				}
+			}
+		})
+	}
+}

--- a/pkg/decoder/tagsl/v1/port5.go
+++ b/pkg/decoder/tagsl/v1/port5.go
@@ -1,5 +1,9 @@
 package tagsl
 
+import (
+	"github.com/truvami/decoder/pkg/common"
+)
+
 // +------+------+-------------------------------------------+-----------+
 // | Byte | Size | Description                               | Format    |
 // +------+------+-------------------------------------------+-----------+
@@ -26,4 +30,20 @@ type Port5Payload struct {
 	Rssi6 int8   `json:"rssi6"`
 	Mac7  string `json:"mac7"`
 	Rssi7 int8   `json:"rssi7"`
+}
+
+var _ common.WifiLocation = &Port5Payload{}
+
+func (p Port5Payload) GetAccessPoints() []common.WifiAccessPoint {
+	var accessPoints []common.WifiAccessPoint
+
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac1, p.Rssi1)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac2, p.Rssi2)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac3, p.Rssi3)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac4, p.Rssi4)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac5, p.Rssi5)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac6, p.Rssi6)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac7, p.Rssi7)
+
+	return accessPoints
 }

--- a/pkg/decoder/tagsl/v1/port50.go
+++ b/pkg/decoder/tagsl/v1/port50.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +------+------+-------------------------------------------+------------------------+
 // | Byte | Size | Description                               | Format                 |
@@ -41,4 +45,46 @@ type Port50Payload struct {
 	Rssi6     int8      `json:"rssi6"`
 	Mac7      string    `json:"mac7"`
 	Rssi7     int8      `json:"rssi7"`
+}
+
+var _ common.Position = &Port50Payload{}
+
+func (p Port50Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port50Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port50Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port50Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port50Payload) GetCapturedAt() *time.Time {
+	return &p.Timestamp
+}
+
+func (p Port50Payload) GetBuffered() bool {
+	return false
+}
+
+var _ common.WifiLocation = &Port50Payload{}
+
+func (p Port50Payload) GetAccessPoints() []common.WifiAccessPoint {
+	var accessPoints []common.WifiAccessPoint
+
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac1, p.Rssi1)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac2, p.Rssi2)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac3, p.Rssi3)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac4, p.Rssi4)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac5, p.Rssi5)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac6, p.Rssi6)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac7, p.Rssi7)
+
+	return accessPoints
 }

--- a/pkg/decoder/tagsl/v1/port51.go
+++ b/pkg/decoder/tagsl/v1/port51.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +------+------+-------------------------------------------+------------------------+
 // | Byte | Size | Description                               | Format                 |
@@ -45,4 +49,46 @@ type Port51Payload struct {
 	Rssi6      int8      `json:"rssi6"`
 	Mac7       string    `json:"mac7"`
 	Rssi7      int8      `json:"rssi7"`
+}
+
+var _ common.Position = &Port51Payload{}
+
+func (p Port51Payload) GetLatitude() float64 {
+	return p.Latitude
+}
+
+func (p Port51Payload) GetLongitude() float64 {
+	return p.Longitude
+}
+
+func (p Port51Payload) GetAltitude() *float64 {
+	return &p.Altitude
+}
+
+func (p Port51Payload) GetSource() common.PositionSource {
+	return common.PositionSource_GNSS
+}
+
+func (p Port51Payload) GetCapturedAt() *time.Time {
+	return &p.Timestamp
+}
+
+func (p Port51Payload) GetBuffered() bool {
+	return false
+}
+
+var _ common.WifiLocation = &Port51Payload{}
+
+func (p Port51Payload) GetAccessPoints() []common.WifiAccessPoint {
+	var accessPoints []common.WifiAccessPoint
+
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac1, p.Rssi1)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac2, p.Rssi2)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac3, p.Rssi3)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac4, p.Rssi4)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac5, p.Rssi5)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac6, p.Rssi6)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac7, p.Rssi7)
+
+	return accessPoints
 }

--- a/pkg/decoder/tagsl/v1/port5_test.go
+++ b/pkg/decoder/tagsl/v1/port5_test.go
@@ -1,0 +1,49 @@
+package tagsl
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/truvami/decoder/pkg/common"
+)
+
+func TestGetAccessPoints(t *testing.T) {
+	payload := &Port5Payload{
+		Mac1:  "001122334455",
+		Rssi1: -50,
+		Mac2:  "66778899aabb",
+		Rssi2: -60,
+		Mac3:  "ccddeeff0011",
+		Rssi3: -70,
+		Mac4:  "223344556677",
+		Rssi4: -80,
+		Mac5:  "8899aabbccdd",
+		Rssi5: -90,
+		Mac6:  "eeff00112233",
+		Rssi6: -100,
+		Mac7:  "445566778899",
+		Rssi7: -110,
+	}
+
+	expected := []common.WifiAccessPoint{
+		{MacAddress: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, Rssi: -50},
+		{MacAddress: net.HardwareAddr{0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB}, Rssi: -60},
+		{MacAddress: net.HardwareAddr{0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11}, Rssi: -70},
+		{MacAddress: net.HardwareAddr{0x22, 0x33, 0x44, 0x55, 0x66, 0x77}, Rssi: -80},
+		{MacAddress: net.HardwareAddr{0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD}, Rssi: -90},
+		{MacAddress: net.HardwareAddr{0xEE, 0xFF, 0x00, 0x11, 0x22, 0x33}, Rssi: -100},
+		{MacAddress: net.HardwareAddr{0x44, 0x55, 0x66, 0x77, 0x88, 0x99}, Rssi: -110},
+	}
+
+	accessPoints := payload.GetAccessPoints()
+	if len(accessPoints) != len(expected) {
+		t.Fatalf("expected %d access points, got %d", len(expected), len(accessPoints))
+	}
+
+	for i, ap := range accessPoints {
+		if !strings.EqualFold(ap.MacAddress.String(), expected[i].MacAddress.String()) || ap.Rssi != expected[i].Rssi {
+			t.Errorf("expected access point %v, got %v", expected[i], ap)
+		}
+	}
+}

--- a/pkg/decoder/tagsl/v1/port7.go
+++ b/pkg/decoder/tagsl/v1/port7.go
@@ -1,6 +1,10 @@
 package tagsl
 
-import "time"
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/common"
+)
 
 // +------+------+-------------------------------------------+-----------+
 // | Byte | Size | Description                               | Format    |
@@ -35,4 +39,19 @@ type Port7Payload struct {
 	Rssi5     int8      `json:"rssi5"`
 	Mac6      string    `json:"mac6"`
 	Rssi6     int8      `json:"rssi6"`
+}
+
+var _ common.WifiLocation = &Port7Payload{}
+
+func (p Port7Payload) GetAccessPoints() []common.WifiAccessPoint {
+	var accessPoints []common.WifiAccessPoint
+
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac1, p.Rssi1)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac2, p.Rssi2)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac3, p.Rssi3)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac4, p.Rssi4)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac5, p.Rssi5)
+	accessPoints = common.AppendAccessPoint(accessPoints, p.Mac6, p.Rssi6)
+
+	return accessPoints
 }


### PR DESCRIPTION
Added two new functions to `Decoder` interface for better integration. Here is an example on how to use the `Decoder`:
```go
package main

import (
	"log"

	"github.com/truvami/decoder/pkg/decoder/tagsl/v1"
)

func main() {
	log.Println("initializing tag S / L decoder...")
	d := tagsl.NewTagSLv1Decoder()

	// decode data
	log.Println("decoding data...")
	location, _, err := d.DecodePosition("0002c420ff005ed85a12b4180719142607", 1, "")
	if err != nil {
		panic(err)
	}

	log.Printf("latitude: %f, longitude: %f, altitude: %f\n", location.GetLatitude(), location.GetLongitude(), *location.GetAltitude())
}

```

New Interface:
```go
package decoder

import "github.com/truvami/decoder/pkg/common"

type Decoder interface {
	Decode(string, int16, string) (interface{}, interface{}, error)
	DecodePosition(string, int16, string) (common.Position, interface{}, error)
	DecodeWifi(string, int16, string) (common.WifiLocation, interface{}, error)
}
