### PR TITLE
Extend loracloud middleware with required fields.

### DIFF
--- a/pkg/decoder/smartlabel/v1/decoder.go
+++ b/pkg/decoder/smartlabel/v1/decoder.go
@@ -16,6 +16,7 @@ type SmartLabelv1Decoder struct {
 	loracloudMiddleware loracloud.LoracloudMiddleware
 	autoPadding         bool
 	skipValidation      bool
+	fCount              uint32
 }
 
 func NewSmartLabelv1Decoder(loracloudMiddleware loracloud.LoracloudMiddleware, options ...Option) decoder.Decoder {
@@ -39,6 +40,14 @@ func WithAutoPadding(autoPadding bool) Option {
 func WithSkipValidation(skipValidation bool) Option {
 	return func(t *SmartLabelv1Decoder) {
 		t.skipValidation = skipValidation
+	}
+}
+
+// WithFCount sets the frame counter for the decoder.
+// This is required for the loracloud middleware.
+func WithFCount(fCount uint32) Option {
+	return func(t *SmartLabelv1Decoder) {
+		t.fCount = fCount
 	}
 }
 
@@ -124,6 +133,7 @@ func (t SmartLabelv1Decoder) Decode(data string, port int16, devEui string) (*de
 			MsgType: "updf",
 			Port:    uint8(port),
 			Payload: data,
+			FCount:  t.fCount,
 		})
 		return decoder.NewDecodedUplink([]decoder.Feature{}, decodedData, nil), err
 	default:

--- a/pkg/decoder/smartlabel/v1/decoder_test.go
+++ b/pkg/decoder/smartlabel/v1/decoder_test.go
@@ -159,7 +159,7 @@ func TestDecode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("TestPort%vWith%v", test.port, test.payload), func(t *testing.T) {
-			decoder := NewSmartLabelv1Decoder(middleware)
+			decoder := NewSmartLabelv1Decoder(middleware, WithFCount(1))
 			got, err := decoder.Decode(test.payload, test.port, test.devEui)
 			if err != nil && len(test.expectedErr) == 0 {
 				t.Fatalf("unexpected error: %v", err)
@@ -265,5 +265,15 @@ func TestGetPort11PayloadType(t *testing.T) {
 				t.Errorf("getPort11PayloadType() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWithFCount(t *testing.T) {
+	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"), WithFCount(123))
+
+	// cast to SmartLabelv1Decoder to access fCount
+	tagXLv1Decoder := decoder.(*SmartLabelv1Decoder)
+	if tagXLv1Decoder.fCount != 123 {
+		t.Fatalf("expected fCount to be 123, got %v", tagXLv1Decoder.fCount)
 	}
 }

--- a/pkg/decoder/tagxl/v1/decoder.go
+++ b/pkg/decoder/tagxl/v1/decoder.go
@@ -15,6 +15,7 @@ type TagXLv1Decoder struct {
 	loracloudMiddleware loracloud.LoracloudMiddleware
 	autoPadding         bool
 	skipValidation      bool
+	fCount              uint32
 }
 
 func NewTagXLv1Decoder(loracloudMiddleware loracloud.LoracloudMiddleware, options ...Option) decoder.Decoder {
@@ -38,6 +39,14 @@ func WithAutoPadding(autoPadding bool) Option {
 func WithSkipValidation(skipValidation bool) Option {
 	return func(t *TagXLv1Decoder) {
 		t.skipValidation = skipValidation
+	}
+}
+
+// WithFCount sets the frame counter for the decoder.
+// This is required for the loracloud middleware.
+func WithFCount(fCount uint32) Option {
+	return func(t *TagXLv1Decoder) {
+		t.fCount = fCount
 	}
 }
 
@@ -92,6 +101,7 @@ func (t TagXLv1Decoder) Decode(data string, port int16, devEui string) (*decoder
 			MsgType: "updf",
 			Port:    uint8(port),
 			Payload: data,
+			FCount:  t.fCount,
 		})
 		return decoder.NewDecodedUplink([]decoder.Feature{}, decodedData, nil), err
 	default:

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -153,7 +153,7 @@ func TestDecode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("TestPort%vWith%v", test.port, test.payload), func(t *testing.T) {
-			decoder := NewTagXLv1Decoder(middleware, WithAutoPadding(test.autoPadding))
+			decoder := NewTagXLv1Decoder(middleware, WithAutoPadding(test.autoPadding), WithFCount(1))
 			got, err := decoder.Decode(test.payload, test.port, test.devEui)
 			if err != nil && len(test.expectedErr) == 0 {
 				t.Fatalf("unexpected error: %v", err)
@@ -306,5 +306,15 @@ func TestFeatures(t *testing.T) {
 				moving.IsMoving()
 			}
 		})
+	}
+}
+
+func TestWithFCount(t *testing.T) {
+	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"), WithFCount(123))
+
+	// cast to TagXLv1Decoder to access fCount
+	tagXLv1Decoder := decoder.(*TagXLv1Decoder)
+	if tagXLv1Decoder.fCount != 123 {
+		t.Fatalf("expected fCount to be 123, got %v", tagXLv1Decoder.fCount)
 	}
 }

--- a/pkg/loracloud/middleware.go
+++ b/pkg/loracloud/middleware.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/go-playground/validator"
 )
 
 type LoracloudMiddleware struct {
@@ -76,6 +78,13 @@ func (m LoracloudMiddleware) post(url string, body []byte) (*http.Response, erro
 //
 // errors: If set and non-empty, error message in case the operation did not succeed.
 func (m LoracloudMiddleware) DeliverUplinkMessage(devEui string, uplinkMsg UplinkMsg) (*UplinkMsgResponse, error) {
+	// validate uplinkMsg
+	validate := validator.New()
+	err := validate.Struct(uplinkMsg)
+	if err != nil {
+		return nil, fmt.Errorf("error validating uplink message: %v", err)
+	}
+
 	url := fmt.Sprintf("%v/api/v1/device/send", m.BaseUrl)
 
 	// format devEui to match ^([0-9a-fA-F]){2}(-([0-9a-fA-F]){2}){7}$
@@ -93,7 +102,7 @@ func (m LoracloudMiddleware) DeliverUplinkMessage(devEui string, uplinkMsg Uplin
 		}, "-")
 	}
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"deveui": devEui,
 		"uplink": uplinkMsg,
 	}
@@ -109,7 +118,7 @@ func (m LoracloudMiddleware) DeliverUplinkMessage(devEui string, uplinkMsg Uplin
 	}
 
 	if response.StatusCode != http.StatusOK {
-		responseJson := map[string]interface{}{}
+		responseJson := map[string]any{}
 		err = json.NewDecoder(response.Body).Decode(&responseJson)
 		if err != nil {
 			return nil, fmt.Errorf("unexpected status code returned by loracloud: HTTP %v", response.StatusCode)
@@ -130,19 +139,19 @@ func (m LoracloudMiddleware) DeliverUplinkMessage(devEui string, uplinkMsg Uplin
 }
 
 type UplinkMsg struct {
-	MsgType                 string     `json:"msgtype"`
-	FCount                  uint32     `json:"fcnt"`
-	Port                    uint8      `json:"port"`
-	Payload                 string     `json:"payload"` // HEX string with LoRaWAN message payload
-	DR                      *uint8     `json:"dr"`
-	Frequency               *uint32    `json:"freq"`
-	Timestamp               *float64   `json:"timestamp"` // RX timestamp in seconds, UTC
-	DNMTU                   *uint32    `json:"dn_mtu"`
-	GNSSCaptureTime         *float64   `json:"gnss_capture_time"`
-	GNSSCaptureTimeAccuracy *float64   `json:"gnss_capture_time_accuracy"`
-	GNSSAssistPosition      *[]float64 `json:"gnss_assist_position"`
-	GNSSAssistAltitude      *float64   `json:"gnss_assist_altitude"`
-	GNSSUse2DSolver         *bool      `json:"gnss_use_2D_solver"`
+	MsgType                 string     `json:"msgtype" validate:"required"`
+	FCount                  uint32     `json:"fcnt" validate:"required"`
+	Port                    uint8      `json:"port" validate:"required"`
+	Payload                 string     `json:"payload" validate:"required"` // HEX string with LoRaWAN message payload
+	DR                      *uint8     `json:"dr,omitempty"`
+	Frequency               *uint32    `json:"freq,omitempty"`
+	Timestamp               *float64   `json:"timestamp,omitempty"` // RX timestamp in seconds, UTC
+	DNMTU                   *uint32    `json:"dn_mtu,omitempty"`
+	GNSSCaptureTime         *float64   `json:"gnss_capture_time,omitempty"`
+	GNSSCaptureTimeAccuracy *float64   `json:"gnss_capture_time_accuracy,omitempty"`
+	GNSSAssistPosition      *[]float64 `json:"gnss_assist_position,omitempty"`
+	GNSSAssistAltitude      *float64   `json:"gnss_assist_altitude,omitempty"`
+	GNSSUse2DSolver         *bool      `json:"gnss_use_2D_solver,omitempty"`
 }
 
 // An “Uplink Response” object reflects the current device state as well as new items resulting from the submitted uplink message.
@@ -174,22 +183,22 @@ type UplinkMsgResponse struct {
 	Result struct {
 		Deveui          string `json:"deveui"`
 		PendingRequests struct {
-			Requests []interface{} `json:"requests"`
-			ID       int           `json:"id"`
-			Updelay  int           `json:"updelay"`
-			Upcount  int           `json:"upcount"`
+			Requests []any `json:"requests"`
+			ID       int   `json:"id"`
+			Updelay  int   `json:"updelay"`
+			Upcount  int   `json:"upcount"`
 		} `json:"pending_requests"`
 		InfoFields struct {
-			Rfu     interface{} `json:"rfu"`
-			Temp    interface{} `json:"temp"`
-			Charge  interface{} `json:"charge"`
-			Deveui  interface{} `json:"deveui"`
-			Region  interface{} `json:"region"`
-			Rxtime  interface{} `json:"rxtime"`
-			Signal  interface{} `json:"signal"`
-			Status  interface{} `json:"status"`
-			Uptime  interface{} `json:"uptime"`
-			Adrmode interface{} `json:"adrmode"`
+			Rfu     any `json:"rfu"`
+			Temp    any `json:"temp"`
+			Charge  any `json:"charge"`
+			Deveui  any `json:"deveui"`
+			Region  any `json:"region"`
+			Rxtime  any `json:"rxtime"`
+			Signal  any `json:"signal"`
+			Status  any `json:"status"`
+			Uptime  any `json:"uptime"`
+			Adrmode any `json:"adrmode"`
 			Alcsync struct {
 				Value struct {
 					Time  int `json:"time"`
@@ -197,13 +206,13 @@ type UplinkMsgResponse struct {
 				} `json:"value"`
 				Timestamp float64 `json:"timestamp"`
 			} `json:"alcsync"`
-			Chipeui interface{} `json:"chipeui"`
-			Joineui interface{} `json:"joineui"`
+			Chipeui any `json:"chipeui"`
+			Joineui any `json:"joineui"`
 			Session struct {
 				Value     int     `json:"value"`
 				Timestamp float64 `json:"timestamp"`
 			} `json:"session"`
-			Voltage  interface{} `json:"voltage"`
+			Voltage  any `json:"voltage"`
 			Crashlog struct {
 				Value     string  `json:"value"`
 				Timestamp float64 `json:"timestamp"`
@@ -216,15 +225,15 @@ type UplinkMsgResponse struct {
 				} `json:"value"`
 				Timestamp float64 `json:"timestamp"`
 			} `json:"firmware"`
-			Interval interface{} `json:"interval"`
+			Interval any `json:"interval"`
 			Rstcount struct {
 				Value     int     `json:"value"`
 				Timestamp float64 `json:"timestamp"`
 			} `json:"rstcount"`
-			Appstatus interface{} `json:"appstatus"`
-			Streampar interface{} `json:"streampar"`
+			Appstatus any `json:"appstatus"`
+			Streampar any `json:"streampar"`
 		} `json:"info_fields"`
-		LogMessages []interface{} `json:"log_messages"`
+		LogMessages []any `json:"log_messages"`
 		Fports      struct {
 			Dmport     int `json:"dmport"`
 			Gnssport   int `json:"gnssport"`
@@ -233,11 +242,11 @@ type UplinkMsgResponse struct {
 			Streamport int `json:"streamport"`
 			Gnssngport int `json:"gnssngport"`
 		} `json:"fports"`
-		Dnlink            interface{}   `json:"dnlink"`
-		FulfilledRequests []interface{} `json:"fulfilled_requests"`
-		CancelledRequests []interface{} `json:"cancelled_requests"`
-		File              interface{}   `json:"file"`
-		StreamRecords     interface{}   `json:"stream_records"`
+		Dnlink            any   `json:"dnlink"`
+		FulfilledRequests []any `json:"fulfilled_requests"`
+		CancelledRequests []any `json:"cancelled_requests"`
+		File              any   `json:"file"`
+		StreamRecords     any   `json:"stream_records"`
 		PositionSolution  struct {
 			Llh             []float64 `json:"llh"`
 			Accuracy        float64   `json:"accuracy"`

--- a/pkg/loracloud/middleware_test.go
+++ b/pkg/loracloud/middleware_test.go
@@ -2,28 +2,28 @@ package loracloud
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
-func startMockServer() *httptest.Server {
-	server := httptest.NewServer(nil)
+func startMockServer(handler http.Handler) *httptest.Server {
+	server := httptest.NewServer(handler)
 	return server
 }
 
 func TestPost(t *testing.T) {
-	http.HandleFunc("/success", func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/success", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	http.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	server := startMockServer()
+	server := startMockServer(mux)
 	middleware := NewLoracloudMiddleware("access_token")
 	middleware.BaseUrl = server.URL
 	defer server.Close()
@@ -54,53 +54,131 @@ func TestPost(t *testing.T) {
 		t.Errorf("expected response: %v, got: %v", http.StatusInternalServerError, response)
 	}
 }
-func TestDeliverUplinkMessage(t *testing.T) {
-	http.HandleFunc("/api/v1/device/send", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Content-Type", "application/json")
 
-		// check if request body contains 0123456789ABCDEC
-		bodyString, _ := io.ReadAll(r.Body)
-		if strings.Contains(string(bodyString), "01-23-45-67-89-AB-CD-EC") {
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte("{\"status\": failed}"))
-			return
+func TestDeliverUplinkMessage(t *testing.T) {
+	t.Run("Successful request", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/v1/device/send", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"result": {
+					"deveui": "01-23-45-67-89-AB-CD-EF",
+					"pending_requests": {
+						"requests": [],
+						"id": 1,
+						"updelay": 0,
+						"upcount": 0
+					},
+					"info_fields": {},
+					"log_messages": [],
+					"fports": {
+						"dmport": 1,
+						"gnssport": 2,
+						"wifiport": 3,
+						"fragport": 4,
+						"streamport": 5,
+						"gnssngport": 6
+					},
+					"operation": "other"
+				}
+			}`))
+		})
+
+		server := startMockServer(mux)
+		middleware := NewLoracloudMiddleware("access_token")
+		middleware.BaseUrl = server.URL
+		defer server.Close()
+
+		devEui := "0123456789ABCDEF"
+		uplinkMsg := UplinkMsg{
+			MsgType: "uplink",
+			FCount:  123,
+			Port:    1,
+			Payload: "0123456789ABCDEF",
 		}
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("{\"status\": \"success\"}"))
+		response, err := middleware.DeliverUplinkMessage(devEui, uplinkMsg)
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+
+		if response.Result.Deveui != "0123456789ABCDEF" {
+			t.Errorf("expected deveui: %v, got: %v", "0123456789ABCDEF", response.Result.Deveui)
+		}
 	})
 
-	server := startMockServer()
-	middleware := NewLoracloudMiddleware("access_token")
-	middleware.BaseUrl = server.URL
+	t.Run("Validation error", func(t *testing.T) {
+		server := startMockServer(nil)
+		middleware := NewLoracloudMiddleware("access_token")
+		middleware.BaseUrl = server.URL
+		defer server.Close()
 
-	defer server.Close()
+		devEui := "0123456789ABCDEF"
+		uplinkMsg := UplinkMsg{
+			MsgType: "",
+			FCount:  123,
+			Port:    1,
+			Payload: "0123456789ABCDEF",
+		}
 
-	// Test case 1: Successful request
-	devEui := "0123456789ABCDEF"
-	uplinkMsg := UplinkMsg{
-		MsgType:                 "uplink",
-		FCount:                  123,
-		Port:                    1,
-		Payload:                 "0123456789ABCDEF",
-		DR:                      nil,
-		Frequency:               nil,
-		Timestamp:               nil,
-		DNMTU:                   nil,
-		GNSSCaptureTime:         nil,
-		GNSSCaptureTimeAccuracy: nil,
-		GNSSAssistPosition:      nil,
-		GNSSAssistAltitude:      nil,
-		GNSSUse2DSolver:         nil,
-	}
+		_, err := middleware.DeliverUplinkMessage(devEui, uplinkMsg)
+		if err == nil || !strings.Contains(err.Error(), "error validating uplink message") {
+			t.Errorf("expected validation error, got: %v", err)
+		}
+	})
 
-	_, err := middleware.DeliverUplinkMessage(devEui, uplinkMsg)
-	if err != nil {
-		t.Errorf("expected no error, got: %v", err)
-	}
+	t.Run("Unexpected status code", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/v1/device/send", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errors": ["Invalid request"]}`))
+		})
 
-	_, err = middleware.DeliverUplinkMessage("0123456789ABCDEC", uplinkMsg)
-	if err == nil {
-		t.Errorf("expected error, got nil")
-	}
+		server := startMockServer(mux)
+		middleware := NewLoracloudMiddleware("access_token")
+		middleware.BaseUrl = server.URL
+		defer server.Close()
+
+		devEui := "0123456789ABCDEF"
+		uplinkMsg := UplinkMsg{
+			MsgType: "uplink",
+			FCount:  123,
+			Port:    1,
+			Payload: "0123456789ABCDEF",
+		}
+
+		_, err := middleware.DeliverUplinkMessage(devEui, uplinkMsg)
+		if err == nil || !strings.Contains(err.Error(), "unexpected status code returned by loracloud") {
+			t.Errorf("expected status code error, got: %v", err)
+		}
+	})
+
+	t.Run("Error decoding response", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/v1/device/send", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`invalid-json`))
+		})
+
+		server := startMockServer(mux)
+		middleware := NewLoracloudMiddleware("access_token")
+		middleware.BaseUrl = server.URL
+		defer server.Close()
+
+		devEui := "0123456789ABCDEF"
+		uplinkMsg := UplinkMsg{
+			MsgType: "uplink",
+			FCount:  123,
+			Port:    1,
+			Payload: "0123456789ABCDEF",
+		}
+
+		_, err := middleware.DeliverUplinkMessage(devEui, uplinkMsg)
+		if err == nil || !strings.Contains(err.Error(), "error decoding loracloud response") {
+			t.Errorf("expected decoding error, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
Currently, when the XL or SmartLabel decoder is used, LoraCloud returns a 400 Bad Request response code. This issue occurs due to the absence of essential fields, such as `fCount`. This PR addresses that by introducing the `fCount` field, ensuring its proper inclusion in requests.

### Key Changes:
- **Added `fCount` field**: This field is now included in requests to prevent the 400 Bad Request error.
- **Validation logic**: A validation step has been added to ensure that invalid requests are prevented. The `fCount` value must be set using the new `WithFCount()` function to guarantee it is properly handled.
- **Decoder interface stability**: The `Decoder` interface remains unchanged to maintain backward compatibility and avoid disrupting existing functionality. The `WithFCount()` function has been specifically chosen to meet this requirement without modifying the interface.

### Rationale:
This approach ensures that the necessary `fCount` field is included while preserving the integrity of the `Decoder` interface, preventing the need for breaking changes. It also provides validation for better error handling and more reliable request processing.