### PR TITLE
Enhanced error messages in `ValidateLength`

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrPortNotSupported = errors.New("port not supported")
+
+	ErrInvalidPayloadLength = errors.New("invalid payload length")
+	ErrPayloadTooShort      = errors.New("payload too short")
+	ErrPayloadTooLong       = errors.New("payload too long")
+)
+
+// WrapError wraps two errors into a single error, combining the parent and child errors.
+// It uses the %w verb to allow the wrapped errors to be unwrapped later.
+//
+// Parameters:
+//   - parent: The outer error that provides context.
+//   - child: The inner error that provides additional details.
+//
+// Returns:
+//
+//	A new error that combines the parent and child errors.
+func WrapError(parent error, child error) error {
+	return fmt.Errorf("%w: %w", parent, child)
+}
+
+// WrapErrorWithMessage wraps two errors (parent and child) with an additional
+// custom message, creating a new error. The resulting error includes the
+// provided message followed by the parent and child errors in a nested format.
+//
+// Parameters:
+//   - parent: The outer error to be wrapped.
+//   - child: The inner error to be wrapped.
+//   - message: A custom message to provide additional context.
+//
+// Returns:
+//   - An error that combines the custom message, parent error, and child error
+//     in a formatted string.
+func WrapErrorWithMessage(parent error, child error, message string) error {
+	return fmt.Errorf("%s: %w: %w", message, parent, child)
+}

--- a/pkg/common/errors_test.go
+++ b/pkg/common/errors_test.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestWrapError(t *testing.T) {
+	parentErr := errors.New("parent error")
+	childErr := errors.New("child error")
+
+	wrappedErr := WrapError(parentErr, childErr)
+
+	// Check if the wrapped error is not nil
+	if wrappedErr == nil {
+		t.Fatalf("expected wrapped error to be non-nil")
+	}
+
+	// Check if the wrapped error contains the parent error
+	if !errors.Is(wrappedErr, parentErr) {
+		t.Errorf("expected wrapped error to contain parent error, but it does not")
+	}
+
+	// Check if the wrapped error contains the child error
+	if !errors.Is(wrappedErr, childErr) {
+		t.Errorf("expected wrapped error to contain child error, but it does not")
+	}
+
+	// Check the error message format
+	expectedMessage := "parent error: child error"
+	if wrappedErr.Error() != expectedMessage {
+		t.Errorf("expected error message '%s', got '%s'", expectedMessage, wrappedErr.Error())
+	}
+}
+
+func TestWrapErrorWithMessage(t *testing.T) {
+	parentErr := errors.New("parent error")
+	childErr := errors.New("child error")
+	message := "custom message"
+
+	wrappedErr := WrapErrorWithMessage(parentErr, childErr, message)
+
+	// Check if the wrapped error is not nil
+	if wrappedErr == nil {
+		t.Fatalf("expected wrapped error to be non-nil")
+	}
+
+	// Check if the wrapped error contains the parent error
+	if !errors.Is(wrappedErr, parentErr) {
+		t.Errorf("expected wrapped error to contain parent error, but it does not")
+	}
+
+	// Check if the wrapped error contains the child error
+	if !errors.Is(wrappedErr, childErr) {
+		t.Errorf("expected wrapped error to contain child error, but it does not")
+	}
+
+	// Check the error message format
+	expectedMessage := "custom message: parent error: child error"
+	if wrappedErr.Error() != expectedMessage {
+		t.Errorf("expected error message '%s', got '%s'", expectedMessage, wrappedErr.Error())
+	}
+}

--- a/pkg/common/helpers.go
+++ b/pkg/common/helpers.go
@@ -214,11 +214,11 @@ func ValidateLength(payload *string, config *PayloadConfig) error {
 	}
 
 	if payloadLength < minLength {
-		return fmt.Errorf("payload too short")
+		return fmt.Errorf("payload too short, expected length %d, got %d", minLength, payloadLength)
 	}
 
 	if payloadLength > maxLength {
-		return fmt.Errorf("payload too long")
+		return fmt.Errorf("payload too long, expected length %d, got %d", maxLength, payloadLength)
 	}
 
 	return nil

--- a/pkg/common/helpers.go
+++ b/pkg/common/helpers.go
@@ -214,11 +214,11 @@ func ValidateLength(payload *string, config *PayloadConfig) error {
 	}
 
 	if payloadLength < minLength {
-		return fmt.Errorf("payload too short, expected length %d, got %d", minLength, payloadLength)
+		return WrapErrorWithMessage(ErrInvalidPayloadLength, ErrPayloadTooShort, fmt.Sprintf("payload length %d is less than minimum required length %d", payloadLength, minLength))
 	}
 
 	if payloadLength > maxLength {
-		return fmt.Errorf("payload too long, expected length %d, got %d", maxLength, payloadLength)
+		return WrapErrorWithMessage(ErrInvalidPayloadLength, ErrPayloadTooLong, fmt.Sprintf("payload length %d is greater than maximum allowed length %d", payloadLength, maxLength))
 	}
 
 	return nil

--- a/pkg/decoder/nomadxl/v1/decoder.go
+++ b/pkg/decoder/nomadxl/v1/decoder.go
@@ -93,7 +93,7 @@ func (t NomadXLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 		}, nil
 	}
 
-	return common.PayloadConfig{}, fmt.Errorf("port %v not supported", port)
+	return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)
 }
 
 func (t NomadXLv1Decoder) Decode(data string, port uint8, devEui string) (*decoder.DecodedUplink, error) {

--- a/pkg/decoder/nomadxl/v1/decoder_test.go
+++ b/pkg/decoder/nomadxl/v1/decoder_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/truvami/decoder/pkg/common"
+	helpers "github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -101,7 +101,7 @@ func TestDecode(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
+	if err == nil || !errors.Is(err, helpers.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -110,7 +110,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("deadbeef", 101, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -119,7 +119,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242", 101, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/nomadxl/v1/decoder_test.go
+++ b/pkg/decoder/nomadxl/v1/decoder_test.go
@@ -108,7 +108,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("deadbeef", 101, "")
 
-	if err == nil || err.Error() != "payload too short" {
+	if err == nil || !strings.Contains(err.Error(), "payload too short") {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -117,7 +117,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242", 101, "")
 
-	if err == nil || err.Error() != "payload too long" {
+	if err == nil || !strings.Contains(err.Error(), "payload too long") {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/nomadxl/v1/decoder_test.go
+++ b/pkg/decoder/nomadxl/v1/decoder_test.go
@@ -2,11 +2,13 @@ package nomadxl
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -99,7 +101,7 @@ func TestDecode(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || err.Error() != "port 0 not supported" {
+	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -108,7 +110,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("deadbeef", 101, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too short") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -117,7 +119,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewNomadXLv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242", 101, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too long") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/nomadxs/v1/decoder.go
+++ b/pkg/decoder/nomadxs/v1/decoder.go
@@ -133,7 +133,7 @@ func (t NomadXSv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 		}, nil
 	}
 
-	return common.PayloadConfig{}, fmt.Errorf("port %v not supported", port)
+	return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)
 }
 
 func (t NomadXSv1Decoder) Decode(data string, port uint8, devEui string) (*decoder.DecodedUplink, error) {

--- a/pkg/decoder/nomadxs/v1/decoder_test.go
+++ b/pkg/decoder/nomadxs/v1/decoder_test.go
@@ -2,11 +2,13 @@ package nomadxs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/truvami/decoder/pkg/common"
 	helpers "github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 )
@@ -293,7 +295,7 @@ func TestValidationErrors(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || err.Error() != "port 0 not supported" {
+	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -302,7 +304,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("deadbeef", 1, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too short") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -311,7 +313,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242", 1, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too long") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/nomadxs/v1/decoder_test.go
+++ b/pkg/decoder/nomadxs/v1/decoder_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/truvami/decoder/pkg/common"
 	helpers "github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 )
@@ -295,7 +294,7 @@ func TestValidationErrors(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
+	if err == nil || !errors.Is(err, helpers.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -304,7 +303,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("deadbeef", 1, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -313,7 +312,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242", 1, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/nomadxs/v1/decoder_test.go
+++ b/pkg/decoder/nomadxs/v1/decoder_test.go
@@ -302,7 +302,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("deadbeef", 1, "")
 
-	if err == nil || err.Error() != "payload too short" {
+	if err == nil || !strings.Contains(err.Error(), "payload too short") {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -311,7 +311,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewNomadXSv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242deadbeef4242", 1, "")
 
-	if err == nil || err.Error() != "payload too long" {
+	if err == nil || !strings.Contains(err.Error(), "payload too long") {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/smartlabel/v1/decoder.go
+++ b/pkg/decoder/smartlabel/v1/decoder.go
@@ -173,7 +173,7 @@ func (t SmartLabelv1Decoder) getConfig(port uint8, data string) (common.PayloadC
 			Features:   []decoder.Feature{decoder.FeatureWiFi},
 		}, nil
 	default:
-		return common.PayloadConfig{}, fmt.Errorf("port %v not supported", port)
+		return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)
 	}
 }
 

--- a/pkg/decoder/smartlabel/v1/decoder_test.go
+++ b/pkg/decoder/smartlabel/v1/decoder_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/truvami/decoder/pkg/common"
+	helpers "github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 	"github.com/truvami/decoder/pkg/loracloud"
 )
@@ -406,7 +406,7 @@ func TestDecode(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
+	if err == nil || !errors.Is(err, helpers.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -415,7 +415,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("0ff0", 1, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -424,7 +424,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("0ff00ff00ff0", 1, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/smartlabel/v1/decoder_test.go
+++ b/pkg/decoder/smartlabel/v1/decoder_test.go
@@ -413,7 +413,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("0ff0", 1, "")
 
-	if err == nil || err.Error() != "payload too short" {
+	if err == nil || !strings.Contains(err.Error(), "payload too short") {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -422,7 +422,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("0ff00ff00ff0", 1, "")
 
-	if err == nil || err.Error() != "payload too long" {
+	if err == nil || !strings.Contains(err.Error(), "payload too long") {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/smartlabel/v1/decoder_test.go
+++ b/pkg/decoder/smartlabel/v1/decoder_test.go
@@ -2,6 +2,7 @@ package smartlabel
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 	"github.com/truvami/decoder/pkg/loracloud"
 )
@@ -404,7 +406,7 @@ func TestDecode(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || err.Error() != "port 0 not supported" {
+	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -413,7 +415,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("0ff0", 1, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too short") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -422,7 +424,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewSmartLabelv1Decoder(loracloud.NewLoracloudMiddleware("appEui"))
 	_, err := decoder.Decode("0ff00ff00ff0", 1, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too long") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -442,7 +442,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 		}, nil
 	}
 
-	return common.PayloadConfig{}, fmt.Errorf("port %v not supported", port)
+	return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)
 }
 
 func (t TagSLv1Decoder) Decode(data string, port uint8, devEui string) (*decoder.DecodedUplink, error) {

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -1765,7 +1765,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("deadbeef", 1, "")
 
-	if err == nil || err.Error() != "payload too short" {
+	if err == nil || !strings.Contains(err.Error(), "payload too short") {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -1774,7 +1774,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242", 1, "")
 
-	if err == nil || err.Error() != "payload too long" {
+	if err == nil || !strings.Contains(err.Error(), "payload too long") {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/truvami/decoder/pkg/common"
 	helpers "github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 )
@@ -1532,7 +1531,7 @@ func TestValidationErrors(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
+	if err == nil || !errors.Is(err, helpers.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -1767,7 +1766,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("deadbeef", 1, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -1776,7 +1775,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242", 1, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2,12 +2,14 @@ package tagsl
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/truvami/decoder/pkg/common"
 	helpers "github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 )
@@ -1530,7 +1532,7 @@ func TestValidationErrors(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || err.Error() != "port 0 not supported" {
+	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -1765,7 +1767,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("deadbeef", 1, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too short") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -1774,7 +1776,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewTagSLv1Decoder()
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242", 1, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too long") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/tagxl/v1/decoder.go
+++ b/pkg/decoder/tagxl/v1/decoder.go
@@ -129,7 +129,7 @@ func (t TagXLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 			Features:   []decoder.Feature{decoder.FeatureWiFi},
 		}, nil
 	}
-	return common.PayloadConfig{}, fmt.Errorf("port %v not supported", port)
+	return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)
 }
 
 func (t TagXLv1Decoder) Decode(data string, port uint8, devEui string) (*decoder.DecodedUplink, error) {

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -350,7 +350,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("deadbeef", 152, "")
 
-	if err == nil || err.Error() != "payload too short" {
+	if err == nil || !strings.Contains(err.Error(), "payload too short") {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -359,7 +359,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242", 152, "")
 
-	if err == nil || err.Error() != "payload too long" {
+	if err == nil || !strings.Contains(err.Error(), "payload too long") {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/truvami/decoder/pkg/common"
+	helpers "github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 	"github.com/truvami/decoder/pkg/loracloud"
 )
@@ -344,7 +344,7 @@ func TestInvalidPort(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("00", 0, "")
 
-	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
+	if err == nil || !errors.Is(err, helpers.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -353,7 +353,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("deadbeef", 152, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -362,7 +362,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242", 152, "")
 
-	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
+	if err == nil || !errors.Is(err, helpers.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -2,6 +2,7 @@ package tagxl
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
 	"github.com/truvami/decoder/pkg/loracloud"
 )
@@ -341,7 +343,8 @@ func TestValidationErrors(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("00", 0, "")
-	if err == nil || err.Error() != "port 0 not supported" {
+
+	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }
@@ -350,7 +353,7 @@ func TestPayloadTooShort(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("deadbeef", 152, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too short") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooShort) {
 		t.Fatal("expected error payload too short")
 	}
 }
@@ -359,7 +362,7 @@ func TestPayloadTooLong(t *testing.T) {
 	decoder := NewTagXLv1Decoder(loracloud.NewLoracloudMiddleware("apiKey"))
 	_, err := decoder.Decode("deadbeef4242deadbeef4242deadbeef4242", 152, "")
 
-	if err == nil || !strings.Contains(err.Error(), "payload too long") {
+	if err == nil || !errors.Is(err, common.ErrPayloadTooLong) {
 		t.Fatal("expected error payload too long")
 	}
 }

--- a/pkg/encoder/tagsl/v1/encoder.go
+++ b/pkg/encoder/tagsl/v1/encoder.go
@@ -95,5 +95,5 @@ func (t TagSLv1Encoder) getConfig(port uint8) (common.PayloadConfig, error) {
 		}, nil
 	}
 
-	return common.PayloadConfig{}, fmt.Errorf("port %v not supported", port)
+	return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)
 }

--- a/pkg/encoder/tagsl/v1/encoder_test.go
+++ b/pkg/encoder/tagsl/v1/encoder_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/truvami/decoder/pkg/common"
+	helpers "github.com/truvami/decoder/pkg/common"
 )
 
 func TestEncode(t *testing.T) {
@@ -152,7 +152,7 @@ func TestInvalidData(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	encoder := NewTagSLv1Encoder()
 	_, _, err := encoder.Encode(nil, 0, "")
-	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
+	if err == nil || !errors.Is(err, helpers.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }

--- a/pkg/encoder/tagsl/v1/encoder_test.go
+++ b/pkg/encoder/tagsl/v1/encoder_test.go
@@ -1,8 +1,11 @@
 package tagsl
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/truvami/decoder/pkg/common"
 )
 
 func TestEncode(t *testing.T) {
@@ -149,7 +152,7 @@ func TestInvalidData(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	encoder := NewTagSLv1Encoder()
 	_, _, err := encoder.Encode(nil, 0, "")
-	if err == nil || err.Error() != "port 0 not supported" {
+	if err == nil || !errors.Is(err, common.ErrPortNotSupported) {
 		t.Fatal("expected port not supported")
 	}
 }


### PR DESCRIPTION
This pull request introduces a new error handling mechanism and updates existing code to use it. The changes include defining new error variables, adding functions to wrap errors, and updating various parts of the codebase to utilize these new functions and error variables.

Error Handling Enhancements:

* [`pkg/common/errors.go`](diffhunk://#diff-c41a146cfaaaff1dcfbd74bb71c443615b15887e1844b56375fa46a263826d68R1-R44): Added new error variables (`ErrPortNotSupported`, `ErrInvalidPayloadLength`, `ErrPayloadTooShort`, `ErrPayloadTooLong`) and functions `WrapError` and `WrapErrorWithMessage` to wrap errors with additional context.
* [`pkg/common/errors_test.go`](diffhunk://#diff-7ac35e96ed2328cec4b7fe9805e9f2342fc7a517ed8d00ef94a38f031edee53dR1-R63): Added tests for the new `WrapError` and `WrapErrorWithMessage` functions to ensure they correctly wrap errors and maintain the error context.

Codebase Updates:

* [`pkg/common/helpers.go`](diffhunk://#diff-d261c39fac580d51f3fc32f8a4a6952587f4e3aa42e24e296241cf35c68abf79L217-R221): Updated `ValidateLength` function to use `WrapErrorWithMessage` for more detailed error messages.
* `pkg/decoder/nomadxl/v1/decoder.go`, `pkg/decoder/nomadxs/v1/decoder.go`, `pkg/decoder/smartlabel/v1/decoder.go`, `pkg/decoder/tagsl/v1/decoder.go`, `pkg/decoder/tagxl/v1/decoder.go`, `pkg/encoder/tagsl/v1/encoder.go`: Updated `getConfig` methods to use the new `ErrPortNotSupported` error variable. [[1]](diffhunk://#diff-435691121bb72de4d6efbf3019a29c40825283c8780fa2d3537e99b26108d2c4L96-R96) [[2]](diffhunk://#diff-bdac392a1d2aeaa6ff1f1fe0652d9e5a4a44d6563a85b29d7f3fd87a64dba61bL136-R136) [[3]](diffhunk://#diff-5900d641fadb851d3b8ad89fb0357881f2fe83d5da75d94ed0c1d11cee370751L176-R176) [[4]](diffhunk://#diff-1f7299fe5c73dd970c6c83174ff7237751acc9e4484a8ee915b36d1cf038e0fdL445-R445) [[5]](diffhunk://#diff-64e4770928c9661e17ca5d6af8b9f3563582f29462e5a66a5d6f192d3242a4fbL132-R132) [[6]](diffhunk://#diff-c356f829376ebc294fb3001f8736a9b00d3ec4a80731c60058ae2c0aebbd6df0L98-R98)

Test Updates:

* `pkg/decoder/nomadxl/v1/decoder_test.go`, `pkg/decoder/nomadxs/v1/decoder_test.go`, `pkg/decoder/smartlabel/v1/decoder_test.go`, `pkg/decoder/tagsl/v1/decoder_test.go`, `pkg/decoder/tagxl/v1/decoder_test.go`, `pkg/encoder/tagsl/v1/encoder_test.go`: Updated tests to check for the new error variables using `errors.Is`. [[1]](diffhunk://#diff-c30dcea0a46093557b29e84a9c73a65a20e0730b435bc609ce925d56a2dcd548L102-R104) [[2]](diffhunk://#diff-f22f3da9bf51390af9c6063066825adff655a9ae47885c4a186623f391f6b265L296-R298) [[3]](diffhunk://#diff-e3356138721ae5362686ca1de85c12e65c0eeabed842815aa13bcc303dacb149L407-R409) [[4]](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3L1533-R1535) [[5]](diffhunk://#diff-6889fdede49e89057f804d6cfe03ca938059d94c2eb1e4dce02699783887422aL344-R347) [[6]](diffhunk://#diff-fd5dc7fcd80a046ae26b6f5a0c7ca395fd4ed3cb8ae8f1278e442ed86dbf9355L152-R155)This pull request includes changes to improve error messages and test cases for payload length validation. The most important changes are grouped into improvements to error messages and updates to test cases.

### Improvements to error messages:

* [`pkg/common/helpers.go`](diffhunk://#diff-d261c39fac580d51f3fc32f8a4a6952587f4e3aa42e24e296241cf35c68abf79L217-R221): Enhanced error messages in `ValidateLength` to include expected and actual lengths for both "too short" and "too long" cases.

### Updates to test cases:

* [`pkg/decoder/nomadxl/v1/decoder_test.go`](diffhunk://#diff-c30dcea0a46093557b29e84a9c73a65a20e0730b435bc609ce925d56a2dcd548L111-R111): Modified `TestPayloadTooShort` and `TestPayloadTooLong` to check for substrings in error messages instead of exact matches. [[1]](diffhunk://#diff-c30dcea0a46093557b29e84a9c73a65a20e0730b435bc609ce925d56a2dcd548L111-R111) [[2]](diffhunk://#diff-c30dcea0a46093557b29e84a9c73a65a20e0730b435bc609ce925d56a2dcd548L120-R120)
* [`pkg/decoder/nomadxs/v1/decoder_test.go`](diffhunk://#diff-f22f3da9bf51390af9c6063066825adff655a9ae47885c4a186623f391f6b265L305-R305): Modified `TestPayloadTooShort` and `TestPayloadTooLong` to check for substrings in error messages instead of exact matches. [[1]](diffhunk://#diff-f22f3da9bf51390af9c6063066825adff655a9ae47885c4a186623f391f6b265L305-R305) [[2]](diffhunk://#diff-f22f3da9bf51390af9c6063066825adff655a9ae47885c4a186623f391f6b265L314-R314)
* [`pkg/decoder/smartlabel/v1/decoder_test.go`](diffhunk://#diff-e3356138721ae5362686ca1de85c12e65c0eeabed842815aa13bcc303dacb149L416-R416): Modified `TestPayloadTooShort` and `TestPayloadTooLong` to check for substrings in error messages instead of exact matches. [[1]](diffhunk://#diff-e3356138721ae5362686ca1de85c12e65c0eeabed842815aa13bcc303dacb149L416-R416) [[2]](diffhunk://#diff-e3356138721ae5362686ca1de85c12e65c0eeabed842815aa13bcc303dacb149L425-R425)
* [`pkg/decoder/tagsl/v1/decoder_test.go`](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3L1768-R1768): Modified `TestPayloadTooShort` and `TestPayloadTooLong` to check for substrings in error messages instead of exact matches. [[1]](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3L1768-R1768) [[2]](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3L1777-R1777)
* [`pkg/decoder/tagxl/v1/decoder_test.go`](diffhunk://#diff-6889fdede49e89057f804d6cfe03ca938059d94c2eb1e4dce02699783887422aL353-R353): Modified `TestPayloadTooShort` and `TestPayloadTooLong` to check for substrings in error messages instead of exact matches. [[1]](diffhunk://#diff-6889fdede49e89057f804d6cfe03ca938059d94c2eb1e4dce02699783887422aL353-R353) [[2]](diffhunk://#diff-6889fdede49e89057f804d6cfe03ca938059d94c2eb1e4dce02699783887422aL362-R362)