### PR TITLE
Added new `Port198Payload` and `FeatureResetReason`.

### DIFF
--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -11,6 +11,7 @@ type Decoder interface {
 type Feature string
 
 const (
+	FeatureResetReason     Feature = "resetReason"
 	FeatureGNSS            Feature = "gnss"
 	FeatureBuffered        Feature = "buffered"
 	FeatureBattery         Feature = "battery"
@@ -161,4 +162,8 @@ type UplinkFeatureHardwareVersion interface {
 
 type UplinkFeatureButton interface {
 	GetPressed() bool
+}
+
+type UplinkFeatureResetReason interface {
+	GetResetReason() ResetReason
 }

--- a/pkg/decoder/reset.go
+++ b/pkg/decoder/reset.go
@@ -1,0 +1,21 @@
+package decoder
+
+type ResetReason string
+
+// TODO: Add more reset reasons and descriptions, check with Viktor
+const (
+	// Device did reset for an unknown reason
+	ResetReasonUnknown ResetReason = "UNKNOWN"
+	// Device did reset because of LRR1110 failure
+	ResetReasonLrr1110FailCode ResetReason = "LRR1110_FAILURE"
+	// Device did reset because of a watchdog timeout
+	ResetReasonWatchdog ResetReason = "WATCHDOG"
+	// Device did reset because of a pin reset
+	ResetReasonPinReset ResetReason = "PIN_RESET"
+	// Device did reset because of a system reset
+	ResetReasonSystemReset ResetReason = "SYSTEM_RESET"
+	// Device did reset because of another reason
+	ResetReasonOtherReset ResetReason = "OTHER_RESET"
+	// Device did reset because of a power reset
+	ResetReasonPowerReset ResetReason = "POWER_RESET"
+)

--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -440,6 +440,14 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 			StatusByteIndex: common.ToIntPointer(2),
 			Features:        []decoder.Feature{decoder.FeatureMoving, decoder.FeatureDutyCycle, decoder.FeatureGNSS, decoder.FeatureBattery, decoder.FeatureWiFi, decoder.FeatureBuffered},
 		}, nil
+	case 198:
+		return common.PayloadConfig{
+			Fields: []common.FieldConfig{
+				{Name: "Reason", Start: 0, Length: 1},
+			},
+			TargetType: reflect.TypeOf(Port198Payload{}),
+			Features:   []decoder.Feature{decoder.FeatureResetReason},
+		}, nil
 	}
 
 	return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -1734,6 +1734,20 @@ func TestFullDecode(t *testing.T) {
 			},
 			port: 105,
 		},
+		{
+			port:    198,
+			payload: "01",
+			expectedData: Port198Payload{
+				Reason: 1,
+			},
+		},
+		{
+			port:    198,
+			payload: "02",
+			expectedData: Port198Payload{
+				Reason: 2,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1755,7 +1769,7 @@ func TestFullDecode(t *testing.T) {
 			}
 
 			// check if status is equal to expected status using reflect.DeepEqual
-			if reflect.DeepEqual(decoded.Metadata, *test.expectedStatus) == false {
+			if test.expectedStatus != nil && reflect.DeepEqual(decoded.Metadata, *test.expectedStatus) == false {
 				t.Errorf("expected status: %v, got: %v", *test.expectedStatus, decoded.Metadata)
 			}
 		})
@@ -1982,6 +1996,15 @@ func TestFeatures(t *testing.T) {
 				if hardwareVersion.GetHardwareVersion() == "" {
 					t.Fatalf("expected non empty hardware version")
 				}
+			}
+
+			if decodedPayload.Is(decoder.FeatureResetReason) {
+				resetReason, ok := decodedPayload.Data.(decoder.UplinkFeatureResetReason)
+				if !ok {
+					t.Fatalf("expected UplinkFeatureResetReason, got %T", decodedPayload)
+				}
+				// call function to check if it panics
+				resetReason.GetResetReason()
 			}
 		})
 	}

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2095,6 +2095,11 @@ func TestMarshal(t *testing.T) {
 			port:     151,
 			expected: []string{"\"moving\": false", "\"timestamp\": \"2024-10-25T17:12:04Z\"", "\"pdop\": 1.5", "\"mac1\": \"e0286d8a9478\"", "\"rssi1\": -53", "\"ttf\": \"24s\""},
 		},
+		{
+			payload:  "01",
+			port:     198,
+			expected: []string{"\"reason\": 1"},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -1865,6 +1865,10 @@ func TestFeatures(t *testing.T) {
 			payload: "00000002d30b27008247b81312671bd164133718030be0286d8a9478cbf0b0140c96bbcea1b2c3d4e5f6aea1b2c3d4e5f6aea1b2c3d4e5f6aea1b2c3d4e5f6ae",
 			port:    151,
 		},
+		{
+			payload: "01",
+			port:    198,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/decoder/tagsl/v1/port198.go
+++ b/pkg/decoder/tagsl/v1/port198.go
@@ -18,20 +18,21 @@ func (p Port198Payload) GetTimestamp() *time.Time {
 }
 
 func (p Port198Payload) GetResetReason() decoder.ResetReason {
-	switch p.Reason {
-	case 1:
-		return decoder.ResetReasonLrr1110FailCode
-	case 2:
-		return decoder.ResetReasonPowerReset
-	case 3:
-		return decoder.ResetReasonPinReset
-	case 4:
-		return decoder.ResetReasonWatchdog
-	case 5:
-		return decoder.ResetReasonSystemReset
-	case 6:
-		return decoder.ResetReasonOtherReset
-	default:
-		return decoder.ResetReasonUnknown
+	var reasonMapping = map[uint8]decoder.ResetReason{
+		1: decoder.ResetReasonLrr1110FailCode,
+		2: decoder.ResetReasonPowerReset,
+		3: decoder.ResetReasonPinReset,
+		4: decoder.ResetReasonWatchdog,
+		5: decoder.ResetReasonSystemReset,
+		6: decoder.ResetReasonOtherReset,
 	}
+
+	// Check if the reason is in the mapping
+	// If it is, return the corresponding ResetReason
+	// If not, return ResetReasonUnknown
+	if reason, ok := reasonMapping[p.Reason]; ok {
+		return reason
+	}
+
+	return decoder.ResetReasonUnknown
 }

--- a/pkg/decoder/tagsl/v1/port198.go
+++ b/pkg/decoder/tagsl/v1/port198.go
@@ -1,0 +1,37 @@
+package tagsl
+
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/decoder"
+)
+
+type Port198Payload struct {
+	Reason uint8 `json:"reason"`
+}
+
+var _ decoder.UplinkFeatureBase = &Port198Payload{}
+var _ decoder.UplinkFeatureResetReason = &Port198Payload{}
+
+func (p Port198Payload) GetTimestamp() *time.Time {
+	return nil
+}
+
+func (p Port198Payload) GetResetReason() decoder.ResetReason {
+	switch p.Reason {
+	case 1:
+		return decoder.ResetReasonLrr1110FailCode
+	case 2:
+		return decoder.ResetReasonPowerReset
+	case 3:
+		return decoder.ResetReasonPinReset
+	case 4:
+		return decoder.ResetReasonWatchdog
+	case 5:
+		return decoder.ResetReasonSystemReset
+	case 6:
+		return decoder.ResetReasonOtherReset
+	default:
+		return decoder.ResetReasonUnknown
+	}
+}


### PR DESCRIPTION
This pull request introduces a new feature to handle reset reasons in the decoder package. It includes the addition of new types, constants, and test cases to support this functionality.

### New Feature: Reset Reason Handling

* Added `FeatureResetReason` to the list of features in `pkg/decoder/decoder.go`.
* Introduced `UplinkFeatureResetReason` interface with the `GetResetReason` method in `pkg/decoder/decoder.go`.
* Created `ResetReason` type and associated constants for various reset reasons in `pkg/decoder/reset.go`.
* Implemented `Port198Payload` struct and methods to handle reset reasons for port 198 in `pkg/decoder/tagsl/v1/port198.go`.

### Test Enhancements

* Added test cases for port 198 payloads to verify reset reason handling in `pkg/decoder/tagsl/v1/decoder_test.go`. [[1]](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3R1737-R1750) [[2]](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3L1758-R1772) [[3]](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3R2000-R2008)