### PR TITLE
fix(smartlabel): port 1 photovoltaic voltage may be close to zero

### DIFF
--- a/pkg/decoder/smartlabel/v1/port1.go
+++ b/pkg/decoder/smartlabel/v1/port1.go
@@ -15,7 +15,7 @@ import (
 
 type Port1Payload struct {
 	BatteryVoltage      float32 `json:"batteryVoltage" validate:"gte=1,lte=5"`
-	PhotovoltaicVoltage float32 `json:"photovoltaicVoltage" validate:"gte=1,lte=5"`
+	PhotovoltaicVoltage float32 `json:"photovoltaicVoltage" validate:"gte=0,lte=5"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port1Payload{}


### PR DESCRIPTION
the smartlabel sends port 1 when it has low battery and since the solar cell may be completely covered, we should allow values starting from 0. this fixes #66 