### PR TITLE
refactor(tagsl): port 198 is no longer screaming reset reason in print

### DIFF
--- a/pkg/decoder/reset.go
+++ b/pkg/decoder/reset.go
@@ -5,17 +5,17 @@ type ResetReason string
 // TODO: Add more reset reasons and descriptions, check with Viktor
 const (
 	// Device did reset for an unknown reason
-	ResetReasonUnknown ResetReason = "UNKNOWN"
+	ResetReasonUnknown ResetReason = "unknown"
 	// Device did reset because of LRR1110 failure
-	ResetReasonLrr1110FailCode ResetReason = "LRR1110_FAILURE"
+	ResetReasonLrr1110FailCode ResetReason = "lrr1110-failure"
 	// Device did reset because of a watchdog timeout
-	ResetReasonWatchdog ResetReason = "WATCHDOG"
+	ResetReasonWatchdog ResetReason = "watchdog"
 	// Device did reset because of a pin reset
-	ResetReasonPinReset ResetReason = "PIN_RESET"
+	ResetReasonPinReset ResetReason = "pin-reset"
 	// Device did reset because of a system reset
-	ResetReasonSystemReset ResetReason = "SYSTEM_RESET"
+	ResetReasonSystemReset ResetReason = "system-reset"
 	// Device did reset because of another reason
-	ResetReasonOtherReset ResetReason = "OTHER_RESET"
+	ResetReasonOtherReset ResetReason = "other-reset"
 	// Device did reset because of a power reset
-	ResetReasonPowerReset ResetReason = "POWER_RESET"
+	ResetReasonPowerReset ResetReason = "power-reset"
 )

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2113,7 +2113,7 @@ func TestMarshal(t *testing.T) {
 		{
 			payload:  "01",
 			port:     198,
-			expected: []string{"\"reason\": \"LRR1110_FAILURE\""},
+			expected: []string{"\"reason\": \"lrr1110-failure\""},
 		},
 	}
 


### PR DESCRIPTION
I think we should not be screaming enum values when printing the decoded payload. 
Not like this.
<img width="1137" alt="Screenshot 2025-05-05 at 10 11 30" src="https://github.com/user-attachments/assets/f3b45d95-4287-4411-946c-c48e44953d1f" />
More like this.
<img width="1145" alt="Screenshot 2025-05-05 at 10 12 46" src="https://github.com/user-attachments/assets/a1f6ba28-de5c-49a1-9fff-e2d7585aef34" />
