### PR TITLE
Support for Port 150 Payloads

### DIFF
--- a/pkg/decoder/tagxl/v1/decoder.go
+++ b/pkg/decoder/tagxl/v1/decoder.go
@@ -3,6 +3,7 @@ package tagxl
 import (
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
@@ -53,6 +54,16 @@ func WithFCount(fCount uint32) Option {
 // https://docs.truvami.com/docs/payloads/tag-xl
 func (t TagXLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 	switch port {
+	case 150:
+		return common.PayloadConfig{
+			Fields: []common.FieldConfig{
+				{Name: "Timestamp", Start: 5, Length: 4, Optional: false, Transform: func(v any) any {
+					return time.Unix(int64(v.(int)), 0).UTC()
+				}},
+			},
+			TargetType: reflect.TypeOf(Port150Payload{}),
+			Features:   []decoder.Feature{},
+		}, nil
 	case 151:
 		return common.PayloadConfig{
 			Fields: []common.FieldConfig{

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -388,6 +388,10 @@ func TestFeatures(t *testing.T) {
 		skipValidation bool
 	}{
 		{
+			payload: "4c07014c04681a5127",
+			port:    150,
+		},
+		{
 			payload: "57012c0258006403e81e3c0dbfd6ce814d0003c0debabe0acd04b9",
 			port:    151,
 		},

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -97,6 +97,20 @@ func TestDecode(t *testing.T) {
 			expectedErr: "port 0 not supported",
 		},
 		{
+			payload: "4c07014c04681a4727",
+			port:    150,
+			expected: Port150Payload{
+				Timestamp: time.Date(2025, 5, 6, 17, 30, 15, 0, time.UTC),
+			},
+		},
+		{
+			payload: "4c07014c04681a5127",
+			port:    150,
+			expected: Port150Payload{
+				Timestamp: time.Date(2025, 5, 6, 18, 12, 55, 0, time.UTC),
+			},
+		},
+		{
 			payload: "0f0078012c000a03e80f1e0e9e7393fffe0002dead10cc0953046e",
 			port:    151,
 			expected: Port151Payload{

--- a/pkg/decoder/tagxl/v1/port150.go
+++ b/pkg/decoder/tagxl/v1/port150.go
@@ -1,0 +1,17 @@
+package tagxl
+
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/decoder"
+)
+
+type Port150Payload struct {
+	Timestamp time.Time `json:"timestamp"`
+}
+
+var _ decoder.UplinkFeatureBase = &Port150Payload{}
+
+func (p Port150Payload) GetTimestamp() *time.Time {
+	return &p.Timestamp
+}


### PR DESCRIPTION
This pull request introduces support for decoding payloads on port 150 in the `tagxl` package. The changes include adding a new payload type, updating the decoder configuration, and enhancing test coverage for the new functionality.

### Support for Port 150 Payloads:

* **Decoder Configuration Update**:
  - Added a case for port 150 in the `getConfig` method of `TagXLv1Decoder`. This includes defining a new `PayloadConfig` with a `Timestamp` field, which is parsed and transformed into a `time.Time` object. (`pkg/decoder/tagxl/v1/decoder.go`, [pkg/decoder/tagxl/v1/decoder.goR57-R66](diffhunk://#diff-64e4770928c9661e17ca5d6af8b9f3563582f29462e5a66a5d6f192d3242a4fbR57-R66))

* **New Payload Type**:
  - Introduced a new struct `Port150Payload` in a dedicated file (`port150.go`). This struct includes a `Timestamp` field and implements the `decoder.UplinkFeatureBase` interface. (`pkg/decoder/tagxl/v1/port150.go`, [pkg/decoder/tagxl/v1/port150.goR1-R17](diffhunk://#diff-179906c5e8cd370db28ffac1f4e3e7772711df47fb4f0f6da45c0ecb1c80abceR1-R17))

### Test Coverage Enhancements:

* **Unit Tests for Port 150**:
  - Added test cases in `TestDecode` to validate decoding of payloads on port 150. These tests ensure the `Timestamp` field is correctly parsed into `time.Time` objects. (`pkg/decoder/tagxl/v1/decoder_test.go`, [pkg/decoder/tagxl/v1/decoder_test.goR99-R112](diffhunk://#diff-6889fdede49e89057f804d6cfe03ca938059d94c2eb1e4dce02699783887422aR99-R112))

### Miscellaneous:

* **Dependency Update**:
  - Added the `time` package to `decoder.go` to support timestamp parsing. (`pkg/decoder/tagxl/v1/decoder.go`, [pkg/decoder/tagxl/v1/decoder.goR6](diffhunk://#diff-64e4770928c9661e17ca5d6af8b9f3563582f29462e5a66a5d6f192d3242a4fbR6))