### PR TITLE
fix(tagsl): decoder returns uplink alongside error

### DIFF
--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -479,7 +479,7 @@ func (t TagSLv1Decoder) Decode(data string, port uint8, devEui string) (*decoder
 
 	decodedData, err := common.Parse(data, &config)
 	if err != nil {
-		return nil, err
+		return decoder.NewDecodedUplink(config.Features, decodedData, nil), err
 	}
 
 	// if there is no status byte index, return the decoded data and nil for status data


### PR DESCRIPTION
Our tagsl is the only one which allows control flow to hit soft errors while returning nil as data. This leads to a null pointer exception and is therefore not very welcome. I fixed this by returning the partially constructed uplink alongside the error. This matches the behaviour of nomadxs, nomadxl, tagxl and the smartlabel. 