### PR TITLE
feat(tagsl): port 15 parse duty cycle and make feature available

### DIFF
--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -221,6 +221,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 	case 15:
 		return common.PayloadConfig{
 			Fields: []common.FieldConfig{
+				{Name: "DutyCycle", Start: 0, Length: 1, Transform: dutyCycle},
 				{Name: "LowBattery", Start: 0, Length: 1},
 				{Name: "Battery", Start: 1, Length: 2, Transform: func(v any) any {
 					return float64(v.(int)) / 1000
@@ -228,7 +229,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 			},
 			TargetType:      reflect.TypeOf(Port15Payload{}),
 			StatusByteIndex: common.ToIntPointer(0),
-			Features:        []decoder.Feature{decoder.FeatureBattery},
+			Features:        []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureBattery},
 		}, nil
 	case 50:
 		return common.PayloadConfig{

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -556,10 +556,11 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			payload:     "800ee5",
+			payload:     "000ee5",
 			port:        15,
 			autoPadding: false,
 			expected: Port15Payload{
+				DutyCycle:  false,
 				LowBattery: false,
 				Battery:    3.813,
 			},
@@ -570,16 +571,28 @@ func TestDecode(t *testing.T) {
 			autoPadding:    false,
 			skipValidation: true,
 			expected: Port15Payload{
+				DutyCycle:  true,
 				LowBattery: false,
 				Battery:    3.813,
 			},
 		},
 		{
-			payload:     "001044",
+			payload:     "011044",
 			port:        15,
 			autoPadding: false,
 			expected: Port15Payload{
-				LowBattery: false,
+				DutyCycle:  false,
+				LowBattery: true,
+				Battery:    4.164,
+			},
+		},
+		{
+			payload:     "811044",
+			port:        15,
+			autoPadding: false,
+			expected: Port15Payload{
+				DutyCycle:  true,
+				LowBattery: true,
 				Battery:    4.164,
 			},
 		},
@@ -588,6 +601,7 @@ func TestDecode(t *testing.T) {
 			port:        15,
 			autoPadding: true,
 			expected: Port15Payload{
+				DutyCycle:  false,
 				LowBattery: false,
 				Battery:    4.164,
 			},

--- a/pkg/decoder/tagsl/v1/port15.go
+++ b/pkg/decoder/tagsl/v1/port15.go
@@ -14,12 +14,14 @@ import (
 // +------+------+---------------------------------------------+------------+
 
 type Port15Payload struct {
+	DutyCycle  bool    `json:"dutyCycle"`
 	LowBattery bool    `json:"lowBattery"`
 	Battery    float64 `json:"battery" validate:"gte=1,lte=5"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port15Payload{}
 var _ decoder.UplinkFeatureBattery = &Port15Payload{}
+var _ decoder.UplinkFeatureDutyCycle = &Port15Payload{}
 
 func (p Port15Payload) GetTimestamp() *time.Time {
 	return nil
@@ -27,4 +29,8 @@ func (p Port15Payload) GetTimestamp() *time.Time {
 
 func (p Port15Payload) GetBatteryVoltage() float64 {
 	return p.Battery
+}
+
+func (p Port15Payload) IsDutyCycle() bool {
+	return p.DutyCycle
 }


### PR DESCRIPTION
Since port 15 on the tagsl is kinda a heartbeat and therefore sent quite frequently I think we should also parse the duty cycle flag which is provided in the status byte. This would help the understanding of devices which are limiting their airtime because there would be more data points in the timeline. 