### PR TITLE
Add decoding logic for legacy port 2 in the `TagSLv1Decoder`.

### DIFF
--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -69,7 +69,10 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 		}, nil
 	case 2:
 		return common.PayloadConfig{
-			Fields:          []common.FieldConfig{},
+			Fields: []common.FieldConfig{
+				{Name: "Moving", Start: 0, Length: 1, Transform: moving},
+				{Name: "DutyCycle", Start: 0, Length: 1, Transform: dutyCycle},
+			},
 			TargetType:      reflect.TypeOf(Port2Payload{}),
 			StatusByteIndex: common.ToIntPointer(0),
 		}, nil

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -77,18 +77,30 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			payload:        "00",
-			port:           2,
-			autoPadding:    false,
-			skipValidation: true,
-			expected:       Port2Payload{},
+			payload:  "00",
+			port:     2,
+			expected: Port2Payload{},
 		},
 		{
-			payload:        "01",
-			port:           2,
-			autoPadding:    false,
-			skipValidation: true,
-			expected:       Port2Payload{},
+			payload:  "00",
+			port:     2,
+			expected: Port2Payload{},
+		},
+		{
+			payload: "01",
+			port:    2,
+			expected: Port2Payload{
+				Moving:    true,
+				DutyCycle: false,
+			},
+		},
+		{
+			payload: "80",
+			port:    2,
+			expected: Port2Payload{
+				Moving:    false,
+				DutyCycle: true,
+			},
 		},
 		{
 			payload:     "822f0101f052fab920feafd0e4158b38b9afe05994cb2f5cb2",

--- a/pkg/decoder/tagsl/v1/port2.go
+++ b/pkg/decoder/tagsl/v1/port2.go
@@ -13,6 +13,8 @@ import (
 // +------+------+-------------------------------------------+--------+
 
 type Port2Payload struct {
+	Moving    bool `json:"moving"`
+	DutyCycle bool `json:"dutyCycle"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port2Payload{}


### PR DESCRIPTION
This pull request enhances the decoding logic for port 2 in the `TagSLv1Decoder` by adding new fields and corresponding tests. Key changes include updates to the payload configuration, the addition of new fields in the `Port2Payload` struct, and expanded test cases to validate the new functionality.

### Enhancements to decoding logic:

* [`pkg/decoder/tagsl/v1/decoder.go`](diffhunk://#diff-1f7299fe5c73dd970c6c83174ff7237751acc9e4484a8ee915b36d1cf038e0fdL72-R75): Updated the `getConfig` method to include two new fields, `Moving` and `DutyCycle`, in the payload configuration for port 2. These fields now have specific start positions, lengths, and transformation functions.

* [`pkg/decoder/tagsl/v1/port2.go`](diffhunk://#diff-20150b0ca5adbd215837306186a9650ee7eef169dd3d5ff56ef8be4f9c0a9e92R16-R17): Added `Moving` and `DutyCycle` as boolean fields to the `Port2Payload` struct to represent the new decoded data.

### Expanded test coverage:

* [`pkg/decoder/tagsl/v1/decoder_test.go`](diffhunk://#diff-cf70b97fc73f31aadc5518c7229b214fefcbd96375932f646e80818151f7cfb3L82-R104): Extended the `TestDecode` function to include new test cases for port 2. These cases validate the decoding of the `Moving` and `DutyCycle` fields with different payload values (`"01"` and `"80"`).