### PR TITLE
refactor(validation): validate all rssi values

### DIFF
--- a/pkg/decoder/smartlabel/v1/port197.go
+++ b/pkg/decoder/smartlabel/v1/port197.go
@@ -27,17 +27,17 @@ import (
 type Port197Payload struct {
 	Tag   byte   `json:"tag"`
 	Mac1  string `json:"mac1"`
-	Rssi1 int8   `json:"rssi1"`
+	Rssi1 int8   `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2  string `json:"mac2"`
-	Rssi2 int8   `json:"rssi2"`
+	Rssi2 int8   `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3  string `json:"mac3"`
-	Rssi3 int8   `json:"rssi3"`
+	Rssi3 int8   `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4  string `json:"mac4"`
-	Rssi4 int8   `json:"rssi4"`
+	Rssi4 int8   `json:"rssi4" validate:"gte=-120,lte=-20"`
 	Mac5  string `json:"mac5"`
-	Rssi5 int8   `json:"rssi5"`
+	Rssi5 int8   `json:"rssi5" validate:"gte=-120,lte=-20"`
 	Mac6  string `json:"mac6"`
-	Rssi6 int8   `json:"rssi6"`
+	Rssi6 int8   `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port197Payload{}

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -323,18 +323,18 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			payload:     "001f3fd57cecb4f0b0140c96bbb2e0286d8a9478b8",
+			payload:     "001f3fd57cecb4c9b0140c96bbb2bd286d8a9478b8ad",
 			port:        5,
 			autoPadding: false,
 			expected: Port5Payload{
 				Moving:    false,
 				DutyCycle: false,
 				Mac1:      "1f3fd57cecb4",
-				Rssi1:     -16,
+				Rssi1:     -55,
 				Mac2:      "b0140c96bbb2",
-				Rssi2:     -32,
+				Rssi2:     -67,
 				Mac3:      "286d8a9478b8",
-				Rssi3:     0,
+				Rssi3:     -83,
 			},
 		},
 		{

--- a/pkg/decoder/tagsl/v1/port105.go
+++ b/pkg/decoder/tagsl/v1/port105.go
@@ -38,17 +38,17 @@ type Port105Payload struct {
 	ConfigChangeSuccess bool      `json:"configChangeSuccess"`
 	Moving              bool      `json:"moving"`
 	Mac1                string    `json:"mac1"`
-	Rssi1               int8      `json:"rssi1"`
+	Rssi1               int8      `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2                string    `json:"mac2"`
-	Rssi2               int8      `json:"rssi2"`
+	Rssi2               int8      `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3                string    `json:"mac3"`
-	Rssi3               int8      `json:"rssi3"`
+	Rssi3               int8      `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4                string    `json:"mac4"`
-	Rssi4               int8      `json:"rssi4"`
+	Rssi4               int8      `json:"rssi4" validate:"gte=-120,lte=-20"`
 	Mac5                string    `json:"mac5"`
-	Rssi5               int8      `json:"rssi5"`
+	Rssi5               int8      `json:"rssi5" validate:"gte=-120,lte=-20"`
 	Mac6                string    `json:"mac6"`
-	Rssi6               int8      `json:"rssi6"`
+	Rssi6               int8      `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port105Payload{}

--- a/pkg/decoder/tagsl/v1/port150.go
+++ b/pkg/decoder/tagsl/v1/port150.go
@@ -47,13 +47,13 @@ type Port150Payload struct {
 	Battery             float64       `json:"battery" validate:"gte=1,lte=5"`
 	TTF                 time.Duration `json:"ttf"`
 	Mac1                string        `json:"mac1"`
-	Rssi1               int8          `json:"rssi1"`
+	Rssi1               int8          `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2                string        `json:"mac2"`
-	Rssi2               int8          `json:"rssi2"`
+	Rssi2               int8          `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3                string        `json:"mac3"`
-	Rssi3               int8          `json:"rssi3"`
+	Rssi3               int8          `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4                string        `json:"mac4"`
-	Rssi4               int8          `json:"rssi4"`
+	Rssi4               int8          `json:"rssi4" validate:"gte=-120,lte=-20"`
 }
 
 func (p Port150Payload) MarshalJSON() ([]byte, error) {

--- a/pkg/decoder/tagsl/v1/port151.go
+++ b/pkg/decoder/tagsl/v1/port151.go
@@ -51,13 +51,13 @@ type Port151Payload struct {
 	PDOP                float64       `json:"pdop"`
 	Satellites          uint8         `json:"satellites" validate:"gte=3,lte=27"`
 	Mac1                string        `json:"mac1"`
-	Rssi1               int8          `json:"rssi1"`
+	Rssi1               int8          `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2                string        `json:"mac2"`
-	Rssi2               int8          `json:"rssi2"`
+	Rssi2               int8          `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3                string        `json:"mac3"`
-	Rssi3               int8          `json:"rssi3"`
+	Rssi3               int8          `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4                string        `json:"mac4"`
-	Rssi4               int8          `json:"rssi4"`
+	Rssi4               int8          `json:"rssi4" validate:"gte=-120,lte=-20"`
 }
 
 func (p Port151Payload) MarshalJSON() ([]byte, error) {

--- a/pkg/decoder/tagsl/v1/port3.go
+++ b/pkg/decoder/tagsl/v1/port3.go
@@ -31,17 +31,17 @@ type Port3Payload struct {
 	TotalMessages  uint8  `json:"totalMessages"`
 	CurrentMessage uint8  `json:"currentMessage"`
 	Mac1           string `json:"mac1"`
-	Rssi1          int8   `json:"rssi1"`
+	Rssi1          int8   `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2           string `json:"mac2"`
-	Rssi2          int8   `json:"rssi2"`
+	Rssi2          int8   `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3           string `json:"mac3"`
-	Rssi3          int8   `json:"rssi3"`
+	Rssi3          int8   `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4           string `json:"mac4"`
-	Rssi4          int8   `json:"rssi4"`
+	Rssi4          int8   `json:"rssi4" validate:"gte=-120,lte=-20"`
 	Mac5           string `json:"mac5"`
-	Rssi5          int8   `json:"rssi5"`
+	Rssi5          int8   `json:"rssi5" validate:"gte=-120,lte=-20"`
 	Mac6           string `json:"mac6"`
-	Rssi6          int8   `json:"rssi6"`
+	Rssi6          int8   `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port3Payload{}

--- a/pkg/decoder/tagsl/v1/port5.go
+++ b/pkg/decoder/tagsl/v1/port5.go
@@ -36,19 +36,19 @@ type Port5Payload struct {
 	ConfigChangeSuccess bool   `json:"configChangeSuccess"`
 	Moving              bool   `json:"moving"`
 	Mac1                string `json:"mac1"`
-	Rssi1               int8   `json:"rssi1"`
+	Rssi1               int8   `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2                string `json:"mac2"`
-	Rssi2               int8   `json:"rssi2"`
+	Rssi2               int8   `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3                string `json:"mac3"`
-	Rssi3               int8   `json:"rssi3"`
+	Rssi3               int8   `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4                string `json:"mac4"`
-	Rssi4               int8   `json:"rssi4"`
+	Rssi4               int8   `json:"rssi4" validate:"gte=-120,lte=-20"`
 	Mac5                string `json:"mac5"`
-	Rssi5               int8   `json:"rssi5"`
+	Rssi5               int8   `json:"rssi5" validate:"gte=-120,lte=-20"`
 	Mac6                string `json:"mac6"`
-	Rssi6               int8   `json:"rssi6"`
+	Rssi6               int8   `json:"rssi6" validate:"gte=-120,lte=-20"`
 	Mac7                string `json:"mac7"`
-	Rssi7               int8   `json:"rssi7"`
+	Rssi7               int8   `json:"rssi7" validate:"gte=-120,lte=-20"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port5Payload{}

--- a/pkg/decoder/tagsl/v1/port50.go
+++ b/pkg/decoder/tagsl/v1/port50.go
@@ -45,13 +45,13 @@ type Port50Payload struct {
 	Battery             float64       `json:"battery" validate:"gte=1,lte=5"`
 	TTF                 time.Duration `json:"ttf"`
 	Mac1                string        `json:"mac1"`
-	Rssi1               int8          `json:"rssi1"`
+	Rssi1               int8          `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2                string        `json:"mac2"`
-	Rssi2               int8          `json:"rssi2"`
+	Rssi2               int8          `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3                string        `json:"mac3"`
-	Rssi3               int8          `json:"rssi3"`
+	Rssi3               int8          `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4                string        `json:"mac4"`
-	Rssi4               int8          `json:"rssi4"`
+	Rssi4               int8          `json:"rssi4" validate:"gte=-120,lte=-20"`
 }
 
 func (p Port50Payload) MarshalJSON() ([]byte, error) {

--- a/pkg/decoder/tagsl/v1/port51.go
+++ b/pkg/decoder/tagsl/v1/port51.go
@@ -49,13 +49,13 @@ type Port51Payload struct {
 	PDOP                float64       `json:"pdop"`
 	Satellites          uint8         `json:"satellites" validate:"gte=3,lte=27"`
 	Mac1                string        `json:"mac1"`
-	Rssi1               int8          `json:"rssi1"`
+	Rssi1               int8          `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2                string        `json:"mac2"`
-	Rssi2               int8          `json:"rssi2"`
+	Rssi2               int8          `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3                string        `json:"mac3"`
-	Rssi3               int8          `json:"rssi3"`
+	Rssi3               int8          `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4                string        `json:"mac4"`
-	Rssi4               int8          `json:"rssi4"`
+	Rssi4               int8          `json:"rssi4" validate:"gte=-120,lte=-20"`
 }
 
 func (p Port51Payload) MarshalJSON() ([]byte, error) {

--- a/pkg/decoder/tagsl/v1/port7.go
+++ b/pkg/decoder/tagsl/v1/port7.go
@@ -36,17 +36,17 @@ type Port7Payload struct {
 	ConfigChangeSuccess bool      `json:"configChangeSuccess"`
 	Moving              bool      `json:"moving"`
 	Mac1                string    `json:"mac1"`
-	Rssi1               int8      `json:"rssi1"`
+	Rssi1               int8      `json:"rssi1" validate:"gte=-120,lte=-20"`
 	Mac2                string    `json:"mac2"`
-	Rssi2               int8      `json:"rssi2"`
+	Rssi2               int8      `json:"rssi2" validate:"gte=-120,lte=-20"`
 	Mac3                string    `json:"mac3"`
-	Rssi3               int8      `json:"rssi3"`
+	Rssi3               int8      `json:"rssi3" validate:"gte=-120,lte=-20"`
 	Mac4                string    `json:"mac4"`
-	Rssi4               int8      `json:"rssi4"`
+	Rssi4               int8      `json:"rssi4" validate:"gte=-120,lte=-20"`
 	Mac5                string    `json:"mac5"`
-	Rssi5               int8      `json:"rssi5"`
+	Rssi5               int8      `json:"rssi5" validate:"gte=-120,lte=-20"`
 	Mac6                string    `json:"mac6"`
-	Rssi6               int8      `json:"rssi6"`
+	Rssi6               int8      `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
 var _ decoder.UplinkFeatureBase = &Port7Payload{}


### PR DESCRIPTION
We had those validations on a single port so far. I think we should be consistent and do it all across the codebase. 