### PR TITLE
feat(tagxl): port 198 now supports optional stacktraces

### DIFF
--- a/pkg/common/helpers.go
+++ b/pkg/common/helpers.go
@@ -64,11 +64,14 @@ func convertFieldToType(value any, fieldType reflect.Type) any {
 
 func extractFieldValue(payloadBytes []byte, start int, length int, optional bool, hexadecimal bool) (any, error) {
 	if length == -1 {
-		if start >= len(payloadBytes) {
+		if start >= len(payloadBytes) && !optional {
 			return nil, fmt.Errorf("field start out of bounds")
 		}
 		// Dynamic length: read until the end of the payload
 		length = len(payloadBytes) - start
+		if length == 0 {
+			return nil, nil
+		}
 	} else if start+length > len(payloadBytes) {
 		if optional {
 			return nil, nil
@@ -316,7 +319,11 @@ func ValidateLength(payload *string, config *PayloadConfig) error {
 
 	var maxLength = 0
 	for _, field := range config.Fields {
-		maxLength = field.Start + field.Length
+		if field.Length == -1 {
+			maxLength = 50
+		} else {
+			maxLength = field.Start + field.Length
+		}
 	}
 
 	if payloadLength < minLength {

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -1546,6 +1546,47 @@ func TestDecode(t *testing.T) {
 				Rssi1:        -88,
 			},
 		},
+		{
+			payload: "02",
+			port:    198,
+			expected: Port198Payload{
+				Reason: 2,
+			},
+		},
+		{
+			payload: "04",
+			port:    198,
+			expected: Port198Payload{
+				Reason: 4,
+			},
+		},
+		{
+			payload: "04313137",
+			port:    198,
+			expected: Port198Payload{
+				Reason: 4,
+				Line:   helpers.StringPtr("117"),
+			},
+		},
+		{
+			payload: "043131373a7372632f6770732e63",
+			port:    198,
+			expected: Port198Payload{
+				Reason: 4,
+				Line:   helpers.StringPtr("117"),
+				File:   helpers.StringPtr("src/gps.c"),
+			},
+		},
+		{
+			payload: "043131373a7372632f6770732e633a6770735f73746172745f6d756c7469706c65",
+			port:    198,
+			expected: Port198Payload{
+				Reason:   4,
+				Line:     helpers.StringPtr("117"),
+				File:     helpers.StringPtr("src/gps.c"),
+				Function: helpers.StringPtr("gps_start_multiple"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/decoder/tagsl/v1/port198.go
+++ b/pkg/decoder/tagsl/v1/port198.go
@@ -8,7 +8,10 @@ import (
 )
 
 type Port198Payload struct {
-	Reason uint8 `json:"reason"`
+	Reason   uint8   `json:"reason"`
+	Line     *string `json:"line"`
+	File     *string `json:"file"`
+	Function *string `json:"function"`
 }
 
 func (p Port198Payload) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
This has been tested with an example payload which I constructed with the help of viktor. 
I currently have no real world examples from trackers to sanity check. 