### PR TITLE
feat(tagsl): support unknown lr1110 199 port

### DIFF
--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -426,6 +426,17 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 			TargetType: reflect.TypeOf(Port198Payload{}),
 			Features:   []decoder.Feature{decoder.FeatureResetReason},
 		}, nil
+	case 199:
+		return common.PayloadConfig{
+			Fields: []common.FieldConfig{
+				{Name: "Constant", Start: 0, Length: 7, Hex: true},
+				{Name: "Sequence", Start: 7, Length: 4},
+				{Name: "Number", Start: 11, Length: 3},
+				{Name: "Id", Start: 14, Length: 1},
+			},
+			TargetType: reflect.TypeOf(Port199Payload{}),
+			Features:   []decoder.Feature{},
+		}, nil
 	}
 
 	return common.PayloadConfig{}, fmt.Errorf("%w: port %v not supported", common.ErrPortNotSupported, port)

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -1587,6 +1587,66 @@ func TestDecode(t *testing.T) {
 				Function: helpers.StringPtr("gps_start_multiple"),
 			},
 		},
+		{
+			payload: "078f64e7dcffff00000f3e00127802",
+			port:    199,
+			expected: Port199Payload{
+				Constant: "078f64e7dcffff",
+				Sequence: 3902,
+				Number:   4728,
+				Id:       2,
+			},
+		},
+		{
+			payload: "078f64e7dcffff00000f3f00127902",
+			port:    199,
+			expected: Port199Payload{
+				Constant: "078f64e7dcffff",
+				Sequence: 3903,
+				Number:   4729,
+				Id:       2,
+			},
+		},
+		{
+			payload: "078f64e7dcffff00000f4000127a02",
+			port:    199,
+			expected: Port199Payload{
+				Constant: "078f64e7dcffff",
+				Sequence: 3904,
+				Number:   4730,
+				Id:       2,
+			},
+		},
+		{
+			payload: "078f64e7dcffff00000f4100127b02",
+			port:    199,
+			expected: Port199Payload{
+				Constant: "078f64e7dcffff",
+				Sequence: 3905,
+				Number:   4731,
+				Id:       2,
+			},
+		},
+		{
+			payload: "078f64e7dcffff00000f4200127c02",
+			port:    199,
+			expected: Port199Payload{
+				Constant: "078f64e7dcffff",
+				Sequence: 3906,
+				Number:   4732,
+				Id:       2,
+			},
+		},
+		{
+			payload: "078f64e7dcffff00000f4300127d02",
+			port:    199,
+			expected: Port199Payload{
+				Constant: "078f64e7dcffff",
+				Sequence: 3907,
+				Number:   4733,
+				Id:       2,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2189,8 +2189,13 @@ func TestFeatures(t *testing.T) {
 			port:    151,
 		},
 		{
-			payload: "01",
+			payload: "043131373a7372632f6770732e633a6770735f73746172745f6d756c7469706c65",
 			port:    198,
+		},
+		{
+			payload:         "078f64e7dcffff00000f4300127d02",
+			port:            199,
+			allowNoFeatures: true,
 		},
 	}
 

--- a/pkg/decoder/tagsl/v1/port199.go
+++ b/pkg/decoder/tagsl/v1/port199.go
@@ -1,0 +1,20 @@
+package tagsl
+
+import (
+	"time"
+
+	"github.com/truvami/decoder/pkg/decoder"
+)
+
+type Port199Payload struct {
+	Constant string `json:"constant"`
+	Sequence uint32 `json:"sequence"`
+	Number   uint32 `json:"number"`
+	Id       uint32 `json:"id"`
+}
+
+var _ decoder.UplinkFeatureBase = &Port199Payload{}
+
+func (p Port199Payload) GetTimestamp() *time.Time {
+	return nil
+}


### PR DESCRIPTION
This is mostly to silence the message flood in the kafka error queue. 