### PR TITLE
refactor(features)!: phase out base in favour of timestamp

### DIFF
--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -12,6 +12,7 @@ type Decoder interface {
 type Feature string
 
 const (
+	FeatureTimestamp       Feature = "timestamp"
 	FeatureResetReason     Feature = "resetReason"
 	FeatureGNSS            Feature = "gnss"
 	FeatureBuffered        Feature = "buffered"
@@ -66,10 +67,7 @@ func (d DecodedUplink) GetFeatures() []Feature {
 	return d.features
 }
 
-type UplinkFeatureBase interface {
-	// GetTimestamp returns the timestamp of the uplink message.
-	// Not all uplink messages have a timestamp, so this method returns a pointer to a time.Time.
-	// If the uplink message does not have a timestamp, the method returns nil.
+type UplinkFeatureTimestamp interface {
 	GetTimestamp() *time.Time
 }
 

--- a/pkg/decoder/nomadxl/v1/decoder_test.go
+++ b/pkg/decoder/nomadxl/v1/decoder_test.go
@@ -112,16 +112,18 @@ func TestFeatures(t *testing.T) {
 			d := NewNomadXLv1Decoder()
 			decodedPayload, _ := d.Decode(context.TODO(), test.payload, test.port)
 
-			// should be able to decode base feature
-			base, ok := decodedPayload.Data.(decoder.UplinkFeatureBase)
-			if !ok {
-				t.Fatalf("expected UplinkFeatureBase, got %T", decodedPayload)
-			}
-			// check if it panics
-			base.GetTimestamp()
-
 			if len(decodedPayload.GetFeatures()) == 0 {
 				t.Error("expected features, got none")
+			}
+
+			if decodedPayload.Is(decoder.FeatureTimestamp) {
+				timestamp, ok := decodedPayload.Data.(decoder.UplinkFeatureTimestamp)
+				if !ok {
+					t.Fatalf("expected UplinkFeatureTimestamp, got %T", decodedPayload)
+				}
+				if timestamp.GetTimestamp() == nil {
+					t.Fatalf("expected non nil timestamp")
+				}
 			}
 
 			if decodedPayload.Is(decoder.FeatureGNSS) {

--- a/pkg/decoder/nomadxl/v1/port101.go
+++ b/pkg/decoder/nomadxl/v1/port101.go
@@ -33,6 +33,7 @@ import (
 // | 46    | 1    | GPS satellite count Galileo                         | uint8               |
 // | 47    | 1    | GPS satellite count Beidou                          | uint8               |
 // | 48-49 | 2    | GPS dilution of precision                           | uint16, cm          |
+// |-------|------|-----------------------------------------------------|---------------------|
 
 type Port101Payload struct {
 	SystemTime         int64         `json:"systemTime"`
@@ -59,15 +60,10 @@ func (p Port101Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port101Payload{}
 var _ decoder.UplinkFeatureBattery = &Port101Payload{}
 var _ decoder.UplinkFeatureTemperature = &Port101Payload{}
 var _ decoder.UplinkFeaturePressure = &Port101Payload{}
 var _ decoder.UplinkFeatureBuffered = &Port101Payload{}
-
-func (p Port101Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port101Payload) GetBatteryVoltage() float64 {
 	return p.Battery

--- a/pkg/decoder/nomadxl/v1/port103.go
+++ b/pkg/decoder/nomadxl/v1/port103.go
@@ -13,6 +13,7 @@ import (
 // | 8-11  | 4    | Latitude    | int32, 1/100'000 deg |
 // | 12-15 | 4    | Longitude   | int32, 1/100'000 deg |
 // | 16-19 | 4    | Altitude    | int32, 1/100 m       |
+// |-------|------|-------------|----------------------|
 
 type Port103Payload struct {
 	UTCDate   uint32  `json:"date"`
@@ -22,12 +23,7 @@ type Port103Payload struct {
 	Altitude  float64 `json:"altitude"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port103Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port103Payload{}
-
-func (p Port103Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port103Payload) GetAccuracy() *float64 {
 	return nil

--- a/pkg/decoder/nomadxs/v1/decoder.go
+++ b/pkg/decoder/nomadxs/v1/decoder.go
@@ -66,7 +66,7 @@ func (t NomadXSv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "MagnetometerZAxis", Start: 40, Length: 2, Optional: true, Transform: magnetometer},
 			},
 			TargetType: reflect.TypeOf(Port1Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTemperature, decoder.FeaturePressure},
+			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp, decoder.FeatureTemperature, decoder.FeaturePressure},
 		}, nil
 	case 4:
 		return common.PayloadConfig{

--- a/pkg/decoder/nomadxs/v1/decoder_test.go
+++ b/pkg/decoder/nomadxs/v1/decoder_test.go
@@ -352,16 +352,18 @@ func TestFeatures(t *testing.T) {
 			d := NewNomadXSv1Decoder()
 			decodedPayload, _ := d.Decode(context.TODO(), test.payload, test.port)
 
-			// should be able to decode base feature
-			base, ok := decodedPayload.Data.(decoder.UplinkFeatureBase)
-			if !ok {
-				t.Fatalf("expected UplinkFeatureBase, got %T", decodedPayload)
-			}
-			// check if it panics
-			base.GetTimestamp()
-
 			if len(decodedPayload.GetFeatures()) == 0 {
 				t.Error("expected features, got none")
+			}
+
+			if decodedPayload.Is(decoder.FeatureTimestamp) {
+				timestamp, ok := decodedPayload.Data.(decoder.UplinkFeatureTimestamp)
+				if !ok {
+					t.Fatalf("expected UplinkFeatureTimestamp, got %T", decodedPayload)
+				}
+				if timestamp.GetTimestamp() == nil {
+					t.Fatalf("expected non nil timestamp")
+				}
 			}
 
 			if decodedPayload.Is(decoder.FeatureGNSS) {

--- a/pkg/decoder/nomadxs/v1/port1.go
+++ b/pkg/decoder/nomadxs/v1/port1.go
@@ -117,7 +117,7 @@ func (p Port1Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port1Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port1Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port1Payload{}
 var _ decoder.UplinkFeatureTemperature = &Port1Payload{}
 var _ decoder.UplinkFeaturePressure = &Port1Payload{}

--- a/pkg/decoder/nomadxs/v1/port15.go
+++ b/pkg/decoder/nomadxs/v1/port15.go
@@ -3,7 +3,6 @@ package nomadxs
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/truvami/decoder/pkg/decoder"
 )
@@ -38,14 +37,9 @@ func (p Port15Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port15Payload{}
 var _ decoder.UplinkFeatureBattery = &Port15Payload{}
 var _ decoder.UplinkFeatureDutyCycle = &Port15Payload{}
 var _ decoder.UplinkFeatureConfigChange = &Port15Payload{}
-
-func (p Port15Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port15Payload) GetBatteryVoltage() float64 {
 	return p.Battery

--- a/pkg/decoder/nomadxs/v1/port4.go
+++ b/pkg/decoder/nomadxs/v1/port4.go
@@ -78,14 +78,9 @@ func (p Port4Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port4Payload{}
 var _ decoder.UplinkFeatureConfig = &Port4Payload{}
 var _ decoder.UplinkFeatureFirmwareVersion = &Port4Payload{}
 var _ decoder.UplinkFeatureHardwareVersion = &Port4Payload{}
-
-func (p Port4Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port4Payload) GetBle() *bool {
 	return nil

--- a/pkg/decoder/smartlabel/v1/decoder_test.go
+++ b/pkg/decoder/smartlabel/v1/decoder_test.go
@@ -529,16 +529,18 @@ func TestFeatures(t *testing.T) {
 				t.Fatalf("error %s", err)
 			}
 
-			// should be able to decode base feature
-			base, ok := decodedPayload.Data.(decoder.UplinkFeatureBase)
-			if !ok {
-				t.Fatalf("expected UplinkFeatureBase, got %T", decodedPayload)
-			}
-			// check if it panics
-			base.GetTimestamp()
-
 			if len(decodedPayload.GetFeatures()) == 0 && !test.allowNoFeatures {
 				t.Error("expected features, got none")
+			}
+
+			if decodedPayload.Is(decoder.FeatureTimestamp) {
+				timestamp, ok := decodedPayload.Data.(decoder.UplinkFeatureTimestamp)
+				if !ok {
+					t.Fatalf("expected UplinkFeatureTimestamp, got %T", decodedPayload)
+				}
+				if timestamp.GetTimestamp() == nil {
+					t.Fatalf("expected non nil timestamp")
+				}
 			}
 
 			if decodedPayload.Is(decoder.FeatureGNSS) {

--- a/pkg/decoder/smartlabel/v1/port1.go
+++ b/pkg/decoder/smartlabel/v1/port1.go
@@ -1,8 +1,6 @@
 package smartlabel
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -18,13 +16,8 @@ type Port1Payload struct {
 	PhotovoltaicVoltage float32 `json:"photovoltaicVoltage" validate:"gte=0,lte=5"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port1Payload{}
 var _ decoder.UplinkFeatureBattery = &Port1Payload{}
 var _ decoder.UplinkFeaturePhotovoltaic = &Port1Payload{}
-
-func (p Port1Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port1Payload) GetBatteryVoltage() float64 {
 	return float64(p.BatteryVoltage)

--- a/pkg/decoder/smartlabel/v1/port11.go
+++ b/pkg/decoder/smartlabel/v1/port11.go
@@ -1,8 +1,6 @@
 package smartlabel
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -22,15 +20,10 @@ type Port11Payload struct {
 	Humidity            float32 `json:"humidity" validate:"gte=5,lte=95"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port11Payload{}
 var _ decoder.UplinkFeatureBattery = &Port11Payload{}
 var _ decoder.UplinkFeaturePhotovoltaic = &Port11Payload{}
 var _ decoder.UplinkFeatureTemperature = &Port11Payload{}
 var _ decoder.UplinkFeatureHumidity = &Port11Payload{}
-
-func (p Port11Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port11Payload) GetBatteryVoltage() float64 {
 	return float64(p.BatteryVoltage)

--- a/pkg/decoder/smartlabel/v1/port150.go
+++ b/pkg/decoder/smartlabel/v1/port150.go
@@ -1,11 +1,5 @@
 package smartlabel
 
-import (
-	"time"
-
-	"github.com/truvami/decoder/pkg/decoder"
-)
-
 // +------+------+---------------------------------------------+--------------+
 // | Byte | Size | Description                                 | Format       |
 // +------+------+---------------------------------------------+--------------+
@@ -22,10 +16,4 @@ type Port150Payload struct {
 	Battery60Voltage  float32 `json:"battery60Voltage" validate:"gte=3.4,lte=3.6"`
 	Battery40Voltage  float32 `json:"battery40Voltage" validate:"gte=3.1,lte=3.4"`
 	Battery20Voltage  float32 `json:"battery20Voltage" validate:"gte=2.7,lte=3.0"`
-}
-
-var _ decoder.UplinkFeatureBase = &Port150Payload{}
-
-func (p Port150Payload) GetTimestamp() *time.Time {
-	return nil
 }

--- a/pkg/decoder/smartlabel/v1/port197.go
+++ b/pkg/decoder/smartlabel/v1/port197.go
@@ -1,8 +1,6 @@
 package smartlabel
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -40,12 +38,7 @@ type Port197Payload struct {
 	Rssi6 *int8   `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port197Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port197Payload{}
-
-func (p Port197Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port197Payload) GetAccessPoints() []decoder.AccessPoint {
 	accessPoints := []decoder.AccessPoint{}

--- a/pkg/decoder/smartlabel/v1/port2.go
+++ b/pkg/decoder/smartlabel/v1/port2.go
@@ -1,8 +1,6 @@
 package smartlabel
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -18,13 +16,8 @@ type Port2Payload struct {
 	Humidity    float32 `json:"humidity" validate:"gte=5,lte=95"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port2Payload{}
 var _ decoder.UplinkFeatureTemperature = &Port2Payload{}
 var _ decoder.UplinkFeatureHumidity = &Port2Payload{}
-
-func (p Port2Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port2Payload) GetTemperature() float32 {
 	return p.Temperature

--- a/pkg/decoder/smartlabel/v1/port4.go
+++ b/pkg/decoder/smartlabel/v1/port4.go
@@ -3,7 +3,6 @@ package smartlabel
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/truvami/decoder/pkg/common"
 	"github.com/truvami/decoder/pkg/decoder"
@@ -57,13 +56,8 @@ func (p Port4Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port4Payload{}
 var _ decoder.UplinkFeatureConfig = &Port4Payload{}
 var _ decoder.UplinkFeatureFirmwareVersion = &Port4Payload{}
-
-func (p Port4Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port4Payload) GetBle() *bool {
 	return nil

--- a/pkg/decoder/tagsl/v1/decoder.go
+++ b/pkg/decoder/tagsl/v1/decoder.go
@@ -55,7 +55,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Second", Start: 16, Length: 1},
 			},
 			TargetType: reflect.TypeOf(Port1Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS},
+			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp},
 		}, nil
 	case 2:
 		return common.PayloadConfig{
@@ -167,7 +167,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Rssi6", Start: 46, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port7Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureWiFi},
+			Features:   []decoder.Feature{decoder.FeatureTimestamp, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureWiFi},
 		}, nil
 	case 8:
 		return common.PayloadConfig{
@@ -202,7 +202,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Satellites", Start: 19, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port10Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureBattery},
+			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp, decoder.FeatureBattery},
 		}, nil
 	case 15:
 		return common.PayloadConfig{
@@ -239,7 +239,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Rssi4", Start: 45, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port50Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureBattery, decoder.FeatureWiFi},
+			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp, decoder.FeatureBattery, decoder.FeatureWiFi},
 		}, nil
 	case 51:
 		return common.PayloadConfig{
@@ -266,7 +266,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Rssi4", Start: 47, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port51Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureBattery, decoder.FeatureWiFi},
+			Features:   []decoder.Feature{decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp, decoder.FeatureBattery, decoder.FeatureWiFi},
 		}, nil
 	case 105:
 		return common.PayloadConfig{
@@ -291,7 +291,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Rssi6", Start: 48, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port105Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureWiFi},
+			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureTimestamp, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureWiFi},
 		}, nil
 	case 110:
 		return common.PayloadConfig{
@@ -311,7 +311,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Satellites", Start: 21, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port110Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureBattery},
+			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp, decoder.FeatureBattery},
 		}, nil
 	case 150:
 		return common.PayloadConfig{
@@ -341,7 +341,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Rssi6", Start: 61, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port150Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureBattery, decoder.FeatureWiFi},
+			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp, decoder.FeatureBattery, decoder.FeatureWiFi},
 		}, nil
 	case 151:
 		return common.PayloadConfig{
@@ -369,7 +369,7 @@ func (t TagSLv1Decoder) getConfig(port uint8) (common.PayloadConfig, error) {
 				{Name: "Rssi4", Start: 49, Length: 1, Optional: true},
 			},
 			TargetType: reflect.TypeOf(Port151Payload{}),
-			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureBattery, decoder.FeatureWiFi},
+			Features:   []decoder.Feature{decoder.FeatureBuffered, decoder.FeatureDutyCycle, decoder.FeatureConfigChange, decoder.FeatureMoving, decoder.FeatureGNSS, decoder.FeatureTimestamp, decoder.FeatureBattery, decoder.FeatureWiFi},
 		}, nil
 	case 198:
 		return common.PayloadConfig{

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2130,16 +2130,18 @@ func TestFeatures(t *testing.T) {
 			d := NewTagSLv1Decoder()
 			decodedPayload, _ := d.Decode(context.TODO(), test.payload, test.port)
 
-			// should be able to decode base feature
-			base, ok := decodedPayload.Data.(decoder.UplinkFeatureBase)
-			if !ok {
-				t.Fatalf("expected UplinkFeatureBase, got %T", decodedPayload)
-			}
-			// check if it panics
-			base.GetTimestamp()
-
 			if len(decodedPayload.GetFeatures()) == 0 && !test.allowNoFeatures {
 				t.Error("expected features, got none")
+			}
+
+			if decodedPayload.Is(decoder.FeatureTimestamp) {
+				timestamp, ok := decodedPayload.Data.(decoder.UplinkFeatureTimestamp)
+				if !ok {
+					t.Fatalf("expected UplinkFeatureTimestamp, got %T", decodedPayload)
+				}
+				if timestamp.GetTimestamp() == nil {
+					t.Fatalf("expected non nil timestamp")
+				}
 			}
 
 			if decodedPayload.Is(decoder.FeatureGNSS) {

--- a/pkg/decoder/tagsl/v1/port1.go
+++ b/pkg/decoder/tagsl/v1/port1.go
@@ -41,8 +41,7 @@ type Port1Payload struct {
 	Second       uint8   `json:"second" validate:"gte=0,lte=59"`
 }
 
-// Enforce that Port1Payload implements interfaces
-var _ decoder.UplinkFeatureBase = &Port1Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port1Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port1Payload{}
 var _ decoder.UplinkFeatureMoving = &Port1Payload{}
 var _ decoder.UplinkFeatureDutyCycle = &Port1Payload{}

--- a/pkg/decoder/tagsl/v1/port10.go
+++ b/pkg/decoder/tagsl/v1/port10.go
@@ -71,7 +71,7 @@ func (p Port10Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port10Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port10Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port10Payload{}
 var _ decoder.UplinkFeatureBattery = &Port10Payload{}
 var _ decoder.UplinkFeatureMoving = &Port10Payload{}

--- a/pkg/decoder/tagsl/v1/port105.go
+++ b/pkg/decoder/tagsl/v1/port105.go
@@ -51,7 +51,7 @@ type Port105Payload struct {
 	Rssi6        *int8     `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port105Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port105Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port105Payload{}
 var _ decoder.UplinkFeatureBuffered = &Port105Payload{}
 var _ decoder.UplinkFeatureMoving = &Port105Payload{}

--- a/pkg/decoder/tagsl/v1/port110.go
+++ b/pkg/decoder/tagsl/v1/port110.go
@@ -73,7 +73,7 @@ func (p Port110Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port110Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port110Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port110Payload{}
 var _ decoder.UplinkFeatureBattery = &Port110Payload{}
 var _ decoder.UplinkFeatureBuffered = &Port110Payload{}

--- a/pkg/decoder/tagsl/v1/port15.go
+++ b/pkg/decoder/tagsl/v1/port15.go
@@ -3,7 +3,6 @@ package tagsl
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/truvami/decoder/pkg/decoder"
 )
@@ -38,14 +37,9 @@ func (p Port15Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port15Payload{}
 var _ decoder.UplinkFeatureBattery = &Port15Payload{}
 var _ decoder.UplinkFeatureDutyCycle = &Port15Payload{}
 var _ decoder.UplinkFeatureConfigChange = &Port15Payload{}
-
-func (p Port15Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port15Payload) GetBatteryVoltage() float64 {
 	return p.Battery

--- a/pkg/decoder/tagsl/v1/port150.go
+++ b/pkg/decoder/tagsl/v1/port150.go
@@ -89,7 +89,7 @@ func (p Port150Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port150Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port150Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port150Payload{}
 var _ decoder.UplinkFeatureBattery = &Port150Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port150Payload{}

--- a/pkg/decoder/tagsl/v1/port151.go
+++ b/pkg/decoder/tagsl/v1/port151.go
@@ -81,7 +81,7 @@ func (p Port151Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port151Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port151Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port151Payload{}
 var _ decoder.UplinkFeatureBattery = &Port151Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port151Payload{}

--- a/pkg/decoder/tagsl/v1/port198.go
+++ b/pkg/decoder/tagsl/v1/port198.go
@@ -2,7 +2,6 @@ package tagsl
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/truvami/decoder/pkg/decoder"
 )
@@ -25,12 +24,7 @@ func (p Port198Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port198Payload{}
 var _ decoder.UplinkFeatureResetReason = &Port198Payload{}
-
-func (p Port198Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port198Payload) GetResetReason() decoder.ResetReason {
 	var reasons = map[uint8]decoder.ResetReason{

--- a/pkg/decoder/tagsl/v1/port199.go
+++ b/pkg/decoder/tagsl/v1/port199.go
@@ -1,20 +1,8 @@
 package tagsl
 
-import (
-	"time"
-
-	"github.com/truvami/decoder/pkg/decoder"
-)
-
 type Port199Payload struct {
 	Constant string `json:"constant"`
 	Sequence uint32 `json:"sequence"`
 	Number   uint32 `json:"number"`
 	Id       uint32 `json:"id"`
-}
-
-var _ decoder.UplinkFeatureBase = &Port199Payload{}
-
-func (p Port199Payload) GetTimestamp() *time.Time {
-	return nil
 }

--- a/pkg/decoder/tagsl/v1/port2.go
+++ b/pkg/decoder/tagsl/v1/port2.go
@@ -1,8 +1,6 @@
 package tagsl
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -23,14 +21,9 @@ type Port2Payload struct {
 	Moving       bool  `json:"moving"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port2Payload{}
 var _ decoder.UplinkFeatureMoving = &Port2Payload{}
 var _ decoder.UplinkFeatureDutyCycle = &Port2Payload{}
 var _ decoder.UplinkFeatureConfigChange = &Port2Payload{}
-
-func (p Port2Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port2Payload) IsMoving() bool {
 	return p.Moving

--- a/pkg/decoder/tagsl/v1/port3.go
+++ b/pkg/decoder/tagsl/v1/port3.go
@@ -1,8 +1,6 @@
 package tagsl
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -44,12 +42,7 @@ type Port3Payload struct {
 	Rssi6          *int8   `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port3Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port3Payload{}
-
-func (p Port3Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port3Payload) GetAccessPoints() []decoder.AccessPoint {
 	accessPoints := []decoder.AccessPoint{}

--- a/pkg/decoder/tagsl/v1/port4.go
+++ b/pkg/decoder/tagsl/v1/port4.go
@@ -82,15 +82,10 @@ func (p Port4Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port4Payload{}
 var _ decoder.UplinkFeatureMoving = &Port4Payload{}
 var _ decoder.UplinkFeatureConfig = &Port4Payload{}
 var _ decoder.UplinkFeatureFirmwareVersion = &Port4Payload{}
 var _ decoder.UplinkFeatureHardwareVersion = &Port4Payload{}
-
-func (p Port4Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port4Payload) GetBle() *bool {
 	return nil

--- a/pkg/decoder/tagsl/v1/port5.go
+++ b/pkg/decoder/tagsl/v1/port5.go
@@ -1,8 +1,6 @@
 package tagsl
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -51,15 +49,10 @@ type Port5Payload struct {
 	Rssi7        *int8   `json:"rssi7" validate:"gte=-120,lte=-20"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port5Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port5Payload{}
 var _ decoder.UplinkFeatureMoving = &Port5Payload{}
 var _ decoder.UplinkFeatureDutyCycle = &Port5Payload{}
 var _ decoder.UplinkFeatureConfigChange = &Port5Payload{}
-
-func (p Port5Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port5Payload) GetAccessPoints() []decoder.AccessPoint {
 	accessPoints := []decoder.AccessPoint{}

--- a/pkg/decoder/tagsl/v1/port50.go
+++ b/pkg/decoder/tagsl/v1/port50.go
@@ -87,7 +87,7 @@ func (p Port50Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port50Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port50Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port50Payload{}
 var _ decoder.UplinkFeatureBattery = &Port50Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port50Payload{}

--- a/pkg/decoder/tagsl/v1/port51.go
+++ b/pkg/decoder/tagsl/v1/port51.go
@@ -95,7 +95,7 @@ func (p Port51Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port51Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port51Payload{}
 var _ decoder.UplinkFeatureGNSS = &Port51Payload{}
 var _ decoder.UplinkFeatureBattery = &Port51Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port51Payload{}

--- a/pkg/decoder/tagsl/v1/port6.go
+++ b/pkg/decoder/tagsl/v1/port6.go
@@ -1,8 +1,6 @@
 package tagsl
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -16,12 +14,7 @@ type Port6Payload struct {
 	ButtonPressed bool `json:"buttonPressed"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port6Payload{}
 var _ decoder.UplinkFeatureButton = &Port6Payload{}
-
-func (p Port6Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port6Payload) GetPressed() bool {
 	return p.ButtonPressed

--- a/pkg/decoder/tagsl/v1/port7.go
+++ b/pkg/decoder/tagsl/v1/port7.go
@@ -49,7 +49,7 @@ type Port7Payload struct {
 	Rssi6        *int8     `json:"rssi6" validate:"gte=-120,lte=-20"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port7Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port7Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port7Payload{}
 var _ decoder.UplinkFeatureMoving = &Port7Payload{}
 var _ decoder.UplinkFeatureDutyCycle = &Port7Payload{}

--- a/pkg/decoder/tagsl/v1/port8.go
+++ b/pkg/decoder/tagsl/v1/port8.go
@@ -1,23 +1,18 @@
 package tagsl
 
-import (
-	"time"
-
-	"github.com/truvami/decoder/pkg/decoder"
-)
-
-// | Byte   | Size | Description                                 | Format                                             |
-// |--------|------|--------------------------------------------|-----------------------------------------------------|
-// | 0-1    | 2    | Scan interval                              | uint16, s                                           |
-// | 2      | 1    | Scan time                                  | uint8, s [0..180]                                   |
-// | 3      | 1    | Max beacons                                | uint8                                               |
-// | 4      | 1    | Min. Rssi value                            | int8                                                |
-// | 5-14   | 10   | Advertising name/eddystone namespace filter | 10 x ASCII or 10 x uint8                           |
-// | 15-16  | 2    | Accelerometer trigger hold timer           | uint16, s                                           |
-// | 17-18  | 2    | Accelerometer threshold                    | uint16, mg                                          |
-// | 19     | 1    | Scan mode                                  | 0 - no filter; 1 - advertised name filter;          |
-// | 		|	   |											| 2 - eddystone namespace filter                      |
-// | 20-21  | 2    | BLE current configuration uplink interval  | uint16, s                                           |
+// | Byte   | Size | Description                                 | Format                                              |
+// |--------|------|---------------------------------------------|-----------------------------------------------------|
+// | 0-1    | 2    | Scan interval                               | uint16, s                                           |
+// | 2      | 1    | Scan time                                   | uint8, s [0..180]                                   |
+// | 3      | 1    | Max beacons                                 | uint8                                               |
+// | 4      | 1    | Min. Rssi value                             | int8                                                |
+// | 5-14   | 10   | Advertising name/eddystone namespace filter | 10 x ASCII or 10 x uint8                            |
+// | 15-16  | 2    | Accelerometer trigger hold timer            | uint16, s                                           |
+// | 17-18  | 2    | Accelerometer threshold                     | uint16, mg                                          |
+// | 19     | 1    | Scan mode                                   | 0 - no filter; 1 - advertised name filter;          |
+// |        |      |                                             | 2 - eddystone namespace filter                      |
+// | 20-21  | 2    | BLE current configuration uplink interval   | uint16, s                                           |
+// |--------|------|---------------------------------------------|-----------------------------------------------------|
 
 type Port8Payload struct {
 	ScanInterval                          uint16 `json:"scanInterval"`
@@ -29,10 +24,4 @@ type Port8Payload struct {
 	AccelerometerThreshold                uint16 `json:"accelerometerThreshold"`
 	ScanMode                              uint8  `json:"scanMode"`
 	BLECurrentConfigurationUplinkInterval uint16 `json:"bleCurrentConfigurationUplinkInterval"`
-}
-
-var _ decoder.UplinkFeatureBase = &Port8Payload{}
-
-func (p Port8Payload) GetTimestamp() *time.Time {
-	return nil
 }

--- a/pkg/decoder/tagxl/v1/decoder.go
+++ b/pkg/decoder/tagxl/v1/decoder.go
@@ -53,7 +53,7 @@ func (t TagXLv1Decoder) getConfig(port uint8, payload []byte) (common.PayloadCon
 				{Name: "Timestamp", Start: 5, Length: 4, Transform: timestamp},
 			},
 			TargetType: reflect.TypeOf(Port150Payload{}),
-			Features:   []decoder.Feature{},
+			Features:   []decoder.Feature{decoder.FeatureTimestamp},
 		}, nil
 	case 151:
 		var payloadType byte = payload[0]
@@ -130,7 +130,7 @@ func (t TagXLv1Decoder) getConfig(port uint8, payload []byte) (common.PayloadCon
 					{Name: "ElapsedSeconds", Start: 9, Length: 4},
 				},
 				TargetType: reflect.TypeOf(Port152Payload{}),
-				Features:   []decoder.Feature{decoder.FeatureRotationState},
+				Features:   []decoder.Feature{decoder.FeatureRotationState, decoder.FeatureTimestamp},
 			}, nil
 		case 0x02:
 			return common.PayloadConfig{
@@ -150,7 +150,7 @@ func (t TagXLv1Decoder) getConfig(port uint8, payload []byte) (common.PayloadCon
 					{Name: "ElapsedSeconds", Start: 10, Length: 4},
 				},
 				TargetType: reflect.TypeOf(Port152Payload{}),
-				Features:   []decoder.Feature{decoder.FeatureRotationState, decoder.FeatureSequenceNumber},
+				Features:   []decoder.Feature{decoder.FeatureSequenceNumber, decoder.FeatureRotationState, decoder.FeatureTimestamp},
 			}, nil
 		default:
 			return common.PayloadConfig{}, fmt.Errorf("%w: version %v for port %d not supported", common.ErrPortNotSupported, version, port)

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -662,16 +662,18 @@ func TestFeatures(t *testing.T) {
 				t.Fatalf("error %s", err)
 			}
 
-			// should be able to decode base feature
-			base, ok := decodedPayload.Data.(decoder.UplinkFeatureBase)
-			if !ok {
-				t.Fatalf("expected UplinkFeatureBase, got %T", decodedPayload)
-			}
-			// check if it panics
-			base.GetTimestamp()
-
 			if len(decodedPayload.GetFeatures()) == 0 && !test.allowNoFeatures {
 				t.Error("expected features, got none")
+			}
+
+			if decodedPayload.Is(decoder.FeatureTimestamp) {
+				timestamp, ok := decodedPayload.Data.(decoder.UplinkFeatureTimestamp)
+				if !ok {
+					t.Fatalf("expected UplinkFeatureTimestamp, got %T", decodedPayload)
+				}
+				if timestamp.GetTimestamp() == nil {
+					t.Fatalf("expected non nil timestamp")
+				}
 			}
 
 			if decodedPayload.Is(decoder.FeatureGNSS) {

--- a/pkg/decoder/tagxl/v1/port150.go
+++ b/pkg/decoder/tagxl/v1/port150.go
@@ -10,7 +10,7 @@ type Port150Payload struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port150Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port150Payload{}
 
 func (p Port150Payload) GetTimestamp() *time.Time {
 	return &p.Timestamp

--- a/pkg/decoder/tagxl/v1/port151.go
+++ b/pkg/decoder/tagxl/v1/port151.go
@@ -1,8 +1,6 @@
 package tagxl
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -54,14 +52,9 @@ type Port151Payload struct {
 	WifiScans                            *uint16  `json:"wifiScans"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port151Payload{}
 var _ decoder.UplinkFeatureBattery = &Port151Payload{}
 var _ decoder.UplinkFeatureConfig = &Port151Payload{}
 var _ decoder.UplinkFeatureFirmwareVersion = &Port151Payload{}
-
-func (p Port151Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port151Payload) GetBatteryVoltage() float64 {
 	return float64(*p.Battery)

--- a/pkg/decoder/tagxl/v1/port152.go
+++ b/pkg/decoder/tagxl/v1/port152.go
@@ -61,7 +61,7 @@ func (p Port152Payload) MarshalJSON() ([]byte, error) {
 	})
 }
 
-var _ decoder.UplinkFeatureBase = &Port152Payload{}
+var _ decoder.UplinkFeatureTimestamp = &Port152Payload{}
 var _ decoder.UplinkFeatureRotationState = &Port152Payload{}
 var _ decoder.UplinkFeatureSequenceNumber = &Port152Payload{}
 

--- a/pkg/decoder/tagxl/v1/port197.go
+++ b/pkg/decoder/tagxl/v1/port197.go
@@ -1,8 +1,6 @@
 package tagxl
 
 import (
-	"time"
-
 	"github.com/truvami/decoder/pkg/decoder"
 )
 
@@ -35,12 +33,7 @@ type Port197Payload struct {
 	Mac5  *string `json:"mac5"`
 }
 
-var _ decoder.UplinkFeatureBase = &Port197Payload{}
 var _ decoder.UplinkFeatureWiFi = &Port197Payload{}
-
-func (p Port197Payload) GetTimestamp() *time.Time {
-	return nil
-}
 
 func (p Port197Payload) GetAccessPoints() []decoder.AccessPoint {
 	accessPoints := []decoder.AccessPoint{}

--- a/pkg/solver/aws/aws.go
+++ b/pkg/solver/aws/aws.go
@@ -165,6 +165,7 @@ func (c PositionEstimateClient) Solve(ctx context.Context, payload string) (*dec
 
 	return decoder.NewDecodedUplink([]decoder.Feature{
 		decoder.FeatureGNSS,
+		decoder.FeatureTimestamp,
 		decoder.FeatureBuffered,
 	}, Position{
 		Latitude:  *position.Coordinates[1],
@@ -201,7 +202,7 @@ type Position struct {
 	Buffered  bool       `json:"buffered"` // Indicates if the position is buffered
 }
 
-var _ decoder.UplinkFeatureBase = &Position{}
+var _ decoder.UplinkFeatureTimestamp = &Position{}
 var _ decoder.UplinkFeatureGNSS = &Position{}
 var _ decoder.UplinkFeatureBuffered = &Position{}
 

--- a/pkg/solver/aws/aws_test.go
+++ b/pkg/solver/aws/aws_test.go
@@ -142,16 +142,18 @@ func TestFeatures(t *testing.T) {
 				t.Fatalf("error %s", err)
 			}
 
-			// should be able to decode base feature
-			base, ok := decodedPayload.Data.(decoder.UplinkFeatureBase)
-			if !ok {
-				t.Fatalf("expected UplinkFeatureBase, got %T", decodedPayload)
-			}
-			// check if it panics
-			base.GetTimestamp()
-
 			if len(decodedPayload.GetFeatures()) == 0 && !test.allowNoFeatures {
 				t.Error("expected features, got none")
+			}
+
+			if decodedPayload.Is(decoder.FeatureTimestamp) {
+				timestamp, ok := decodedPayload.Data.(decoder.UplinkFeatureTimestamp)
+				if !ok {
+					t.Fatalf("expected UplinkFeatureTimestamp, got %T", decodedPayload)
+				}
+				if timestamp.GetTimestamp() == nil {
+					t.Fatalf("expected non nil timestamp")
+				}
 			}
 
 			if decodedPayload.Is(decoder.FeatureGNSS) {

--- a/pkg/solver/loracloud/middleware.go
+++ b/pkg/solver/loracloud/middleware.go
@@ -338,7 +338,7 @@ type UplinkMsgResponse struct {
 	} `json:"result"`
 }
 
-var _ decoder.UplinkFeatureBase = &UplinkMsgResponse{}
+var _ decoder.UplinkFeatureTimestamp = &UplinkMsgResponse{}
 var _ decoder.UplinkFeatureGNSS = &UplinkMsgResponse{}
 
 func (p UplinkMsgResponse) GetTimestamp() *time.Time {


### PR DESCRIPTION
This is kinda a proposal. I think we should have a timestamp feature rather than a base feature which would only be present if said port possesses a timestamp. I will adjust the bridge myself, let me know what you think about it. You may dismiss or review this pull request, it's up to you. 