### PR TITLE
refactor(decoder): expand buffered feature and make level optional

### DIFF
--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -90,7 +90,7 @@ type UplinkFeatureGNSS interface {
 }
 
 type UplinkFeatureBuffered interface {
-	GetIsBuffered() bool
+	IsBuffered() bool
 	GetBufferLevel() *uint16
 }
 

--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -90,8 +90,8 @@ type UplinkFeatureGNSS interface {
 }
 
 type UplinkFeatureBuffered interface {
-	// GetBufferLevel returns the buffer level of the device.
-	GetBufferLevel() uint16
+	GetIsBuffered() bool
+	GetBufferLevel() *uint16
 }
 
 type UplinkFeatureBattery interface {

--- a/pkg/decoder/nomadxl/v1/decoder_test.go
+++ b/pkg/decoder/nomadxl/v1/decoder_test.go
@@ -168,6 +168,7 @@ func TestFeatures(t *testing.T) {
 					t.Fatalf("expected UplinkFeatureBuffered, got %T", decodedPayload)
 				}
 				// call function to check if it panics
+				buffered.GetIsBuffered()
 				buffered.GetBufferLevel()
 			}
 			if decodedPayload.Is(decoder.FeatureBattery) {

--- a/pkg/decoder/nomadxl/v1/decoder_test.go
+++ b/pkg/decoder/nomadxl/v1/decoder_test.go
@@ -168,7 +168,7 @@ func TestFeatures(t *testing.T) {
 					t.Fatalf("expected UplinkFeatureBuffered, got %T", decodedPayload)
 				}
 				// call function to check if it panics
-				buffered.GetIsBuffered()
+				buffered.IsBuffered()
 				buffered.GetBufferLevel()
 			}
 			if decodedPayload.Is(decoder.FeatureBattery) {

--- a/pkg/decoder/nomadxl/v1/port101.go
+++ b/pkg/decoder/nomadxl/v1/port101.go
@@ -85,7 +85,7 @@ func (p Port101Payload) GetPressure() float32 {
 	return p.Pressure
 }
 
-func (p Port101Payload) GetIsBuffered() bool {
+func (p Port101Payload) IsBuffered() bool {
 	return false
 }
 

--- a/pkg/decoder/nomadxl/v1/port101.go
+++ b/pkg/decoder/nomadxl/v1/port101.go
@@ -85,6 +85,10 @@ func (p Port101Payload) GetPressure() float32 {
 	return p.Pressure
 }
 
-func (p Port101Payload) GetBufferLevel() uint16 {
-	return 0
+func (p Port101Payload) GetIsBuffered() bool {
+	return false
+}
+
+func (p Port101Payload) GetBufferLevel() *uint16 {
+	return nil
 }

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2168,7 +2168,7 @@ func TestFeatures(t *testing.T) {
 					t.Fatalf("expected UplinkFeatureBuffered, got %T", decodedPayload)
 				}
 				// call function to check if it panics
-				buffered.GetIsBuffered()
+				buffered.IsBuffered()
 				buffered.GetBufferLevel()
 			}
 			if decodedPayload.Is(decoder.FeatureBattery) {

--- a/pkg/decoder/tagsl/v1/decoder_test.go
+++ b/pkg/decoder/tagsl/v1/decoder_test.go
@@ -2168,6 +2168,7 @@ func TestFeatures(t *testing.T) {
 					t.Fatalf("expected UplinkFeatureBuffered, got %T", decodedPayload)
 				}
 				// call function to check if it panics
+				buffered.GetIsBuffered()
 				buffered.GetBufferLevel()
 			}
 			if decodedPayload.Is(decoder.FeatureBattery) {

--- a/pkg/decoder/tagsl/v1/port105.go
+++ b/pkg/decoder/tagsl/v1/port105.go
@@ -110,7 +110,7 @@ func (p Port105Payload) GetAccessPoints() []decoder.AccessPoint {
 	return accessPoints
 }
 
-func (p Port105Payload) GetIsBuffered() bool {
+func (p Port105Payload) IsBuffered() bool {
 	return true
 }
 

--- a/pkg/decoder/tagsl/v1/port105.go
+++ b/pkg/decoder/tagsl/v1/port105.go
@@ -110,8 +110,12 @@ func (p Port105Payload) GetAccessPoints() []decoder.AccessPoint {
 	return accessPoints
 }
 
-func (p Port105Payload) GetBufferLevel() uint16 {
-	return p.BufferLevel
+func (p Port105Payload) GetIsBuffered() bool {
+	return true
+}
+
+func (p Port105Payload) GetBufferLevel() *uint16 {
+	return &p.BufferLevel
 }
 
 func (p Port105Payload) IsMoving() bool {

--- a/pkg/decoder/tagsl/v1/port110.go
+++ b/pkg/decoder/tagsl/v1/port110.go
@@ -121,7 +121,7 @@ func (p Port110Payload) GetLowBattery() *bool {
 	return nil
 }
 
-func (p Port110Payload) GetIsBuffered() bool {
+func (p Port110Payload) IsBuffered() bool {
 	return true
 }
 

--- a/pkg/decoder/tagsl/v1/port110.go
+++ b/pkg/decoder/tagsl/v1/port110.go
@@ -121,8 +121,12 @@ func (p Port110Payload) GetLowBattery() *bool {
 	return nil
 }
 
-func (p Port110Payload) GetBufferLevel() uint16 {
-	return p.BufferLevel
+func (p Port110Payload) GetIsBuffered() bool {
+	return true
+}
+
+func (p Port110Payload) GetBufferLevel() *uint16 {
+	return &p.BufferLevel
 }
 
 func (p Port110Payload) IsMoving() bool {

--- a/pkg/decoder/tagsl/v1/port150.go
+++ b/pkg/decoder/tagsl/v1/port150.go
@@ -172,7 +172,7 @@ func (p Port150Payload) GetAccessPoints() []decoder.AccessPoint {
 	return accessPoints
 }
 
-func (p Port150Payload) GetIsBuffered() bool {
+func (p Port150Payload) IsBuffered() bool {
 	return true
 }
 

--- a/pkg/decoder/tagsl/v1/port150.go
+++ b/pkg/decoder/tagsl/v1/port150.go
@@ -172,8 +172,12 @@ func (p Port150Payload) GetAccessPoints() []decoder.AccessPoint {
 	return accessPoints
 }
 
-func (p Port150Payload) GetBufferLevel() uint16 {
-	return p.BufferLevel
+func (p Port150Payload) GetIsBuffered() bool {
+	return true
+}
+
+func (p Port150Payload) GetBufferLevel() *uint16 {
+	return &p.BufferLevel
 }
 
 func (p Port150Payload) IsMoving() bool {

--- a/pkg/decoder/tagsl/v1/port151.go
+++ b/pkg/decoder/tagsl/v1/port151.go
@@ -164,7 +164,7 @@ func (p Port151Payload) GetAccessPoints() []decoder.AccessPoint {
 	return accessPoints
 }
 
-func (p Port151Payload) GetIsBuffered() bool {
+func (p Port151Payload) IsBuffered() bool {
 	return true
 }
 

--- a/pkg/decoder/tagsl/v1/port151.go
+++ b/pkg/decoder/tagsl/v1/port151.go
@@ -164,8 +164,12 @@ func (p Port151Payload) GetAccessPoints() []decoder.AccessPoint {
 	return accessPoints
 }
 
-func (p Port151Payload) GetBufferLevel() uint16 {
-	return p.BufferLevel
+func (p Port151Payload) GetIsBuffered() bool {
+	return true
+}
+
+func (p Port151Payload) GetBufferLevel() *uint16 {
+	return &p.BufferLevel
 }
 
 func (p Port151Payload) IsMoving() bool {

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -664,7 +664,7 @@ func TestFeatures(t *testing.T) {
 					t.Fatalf("expected UplinkFeatureBuffered, got %T", decodedPayload)
 				}
 				// call function to check if it panics
-				buffered.GetIsBuffered()
+				buffered.IsBuffered()
 				buffered.GetBufferLevel()
 			}
 			if decodedPayload.Is(decoder.FeatureBattery) {

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -664,6 +664,7 @@ func TestFeatures(t *testing.T) {
 					t.Fatalf("expected UplinkFeatureBuffered, got %T", decodedPayload)
 				}
 				// call function to check if it panics
+				buffered.GetIsBuffered()
 				buffered.GetBufferLevel()
 			}
 			if decodedPayload.Is(decoder.FeatureBattery) {


### PR DESCRIPTION
We expand feature buffered with the is buffered boolean and make buffer level optional as not all devices have one. 
This will help you for your aws feature branch as you can pull this in after it is merged to main. 