### PR TITLE
Refactor Middleware to support Traxmate

### DIFF
--- a/cmd/http.go
+++ b/cmd/http.go
@@ -93,7 +93,7 @@ var httpCmd = &cobra.Command{
 				logger.Logger.Error("loracloud access token is required for loracloud solver")
 				os.Exit(1)
 			}
-			solver = loracloud.NewLoracloudMiddleware(ctx, LoracloudAccessToken, logger.Logger)
+			solver = loracloud.NewLoracloudClient(ctx, LoracloudAccessToken, logger.Logger)
 		}
 
 		var decoders []decoderEndpoint = []decoderEndpoint{

--- a/cmd/smartlabel.go
+++ b/cmd/smartlabel.go
@@ -50,7 +50,7 @@ var smartlabelCmd = &cobra.Command{
 				logger.Logger.Error("loracloud access token is required for loracloud solver")
 				os.Exit(1)
 			}
-			solver = loracloud.NewLoracloudMiddleware(ctx, LoracloudAccessToken, logger.Logger)
+			solver = loracloud.NewLoracloudClient(ctx, LoracloudAccessToken, logger.Logger)
 		}
 
 		logger.Logger.Debug("initializing smartlabel decoder")

--- a/cmd/tagxl.go
+++ b/cmd/tagxl.go
@@ -50,7 +50,7 @@ var tagxlCmd = &cobra.Command{
 				logger.Logger.Error("loracloud access token is required for loracloud solver")
 				os.Exit(1)
 			}
-			solver = loracloud.NewLoracloudMiddleware(ctx, LoracloudAccessToken, logger.Logger)
+			solver = loracloud.NewLoracloudClient(ctx, LoracloudAccessToken, logger.Logger)
 		}
 
 		logger.Logger.Debug("initializing tagxl decoder")

--- a/pkg/decoder/smartlabel/v1/decoder_test.go
+++ b/pkg/decoder/smartlabel/v1/decoder_test.go
@@ -57,7 +57,7 @@ func TestDecode(t *testing.T) {
 	})
 
 	server := startMockServer(nil)
-	middleware := loracloud.NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+	middleware := loracloud.NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 	middleware.BaseUrl = server.URL
 	defer server.Close()
 
@@ -507,7 +507,7 @@ func TestFeatures(t *testing.T) {
 	})
 
 	server := startMockServer(mux)
-	middleware := loracloud.NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+	middleware := loracloud.NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 	middleware.BaseUrl = server.URL
 	defer server.Close()
 

--- a/pkg/decoder/tagxl/v1/decoder_test.go
+++ b/pkg/decoder/tagxl/v1/decoder_test.go
@@ -59,7 +59,7 @@ func TestDecode(t *testing.T) {
 	})
 
 	server := startMockServer(nil)
-	middleware := loracloud.NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+	middleware := loracloud.NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 	middleware.BaseUrl = server.URL
 	defer server.Close()
 
@@ -645,7 +645,7 @@ func TestFeatures(t *testing.T) {
 	})
 
 	server := startMockServer(mux)
-	middleware := loracloud.NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+	middleware := loracloud.NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 	middleware.BaseUrl = server.URL
 	defer server.Close()
 

--- a/pkg/solver/aws/aws.go
+++ b/pkg/solver/aws/aws.go
@@ -10,44 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iotwireless"
 	"github.com/aws/aws-sdk-go-v2/service/iotwireless/types"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/truvami/decoder/pkg/decoder"
 	"github.com/truvami/decoder/pkg/solver"
 	"go.uber.org/zap"
-)
-
-var (
-	awsPositionEstimatesTotalCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "truvami_aws_position_estimates_total",
-		Help: "The total number of processed position estimate requests",
-	})
-	awsPositionEstimatesErrorsCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "truvami_aws_position_estimates_errors_total",
-		Help: "The total number of errors encountered while processing position estimate requests",
-	})
-	awsPositionEstimatesDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "truvami_aws_position_estimates_duration_seconds",
-		Help:    "The duration of position estimate requests in seconds",
-		Buckets: []float64{0.1, 0.2, 0.3, 0.5, 1, 2, 5, 10, 30, 60},
-	})
-	awsPositionEstimatesSuccessCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "truvami_aws_position_estimates_success_total",
-		Help: "The total number of successful position estimate requests",
-	})
-	awsPositionEstimatesFailureCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "truvami_aws_position_estimates_failure_total",
-		Help: "The total number of failed position estimate requests",
-	})
-
-	AwsLoracloudFallbackSuccess = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "truvami_aws_loracloud_fallback_success_total",
-		Help: "The total number of successful position estimate requests using Loracloud as a fallback",
-	})
-	AwsLoracloudFallbackFailure = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "truvami_aws_loracloud_fallback_failure_total",
-		Help: "The total number of failed position estimate requests using Loracloud as a fallback",
-	})
 )
 
 type PositionEstimateClient struct {

--- a/pkg/solver/aws/metrics.go
+++ b/pkg/solver/aws/metrics.go
@@ -1,0 +1,39 @@
+package aws
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	awsPositionEstimatesTotalCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "truvami_aws_position_estimates_total",
+		Help: "The total number of processed position estimate requests",
+	})
+	awsPositionEstimatesErrorsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "truvami_aws_position_estimates_errors_total",
+		Help: "The total number of errors encountered while processing position estimate requests",
+	})
+	awsPositionEstimatesDurationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "truvami_aws_position_estimates_duration_seconds",
+		Help:    "The duration of position estimate requests in seconds",
+		Buckets: []float64{0.1, 0.2, 0.3, 0.5, 1, 2, 5, 10, 30, 60},
+	})
+	awsPositionEstimatesSuccessCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "truvami_aws_position_estimates_success_total",
+		Help: "The total number of successful position estimate requests",
+	})
+	awsPositionEstimatesFailureCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "truvami_aws_position_estimates_failure_total",
+		Help: "The total number of failed position estimate requests",
+	})
+
+	AwsLoracloudFallbackSuccess = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "truvami_aws_loracloud_fallback_success_total",
+		Help: "The total number of successful position estimate requests using Loracloud as a fallback",
+	})
+	AwsLoracloudFallbackFailure = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "truvami_aws_loracloud_fallback_failure_total",
+		Help: "The total number of failed position estimate requests using Loracloud as a fallback",
+	})
+)

--- a/pkg/solver/loracloud/loracloud_test.go
+++ b/pkg/solver/loracloud/loracloud_test.go
@@ -31,7 +31,7 @@ func TestPost(t *testing.T) {
 	})
 
 	server := startMockServer(mux)
-	middleware := NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+	middleware := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 	middleware.BaseUrl = server.URL
 	defer server.Close()
 
@@ -93,7 +93,7 @@ func TestDeliverUplinkMessage(t *testing.T) {
 		})
 
 		server := startMockServer(mux)
-		middleware := NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+		middleware := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 		middleware.BaseUrl = server.URL
 		defer server.Close()
 
@@ -117,7 +117,7 @@ func TestDeliverUplinkMessage(t *testing.T) {
 
 	t.Run("Validation error", func(t *testing.T) {
 		server := startMockServer(nil)
-		middleware := NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+		middleware := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 		middleware.BaseUrl = server.URL
 		defer server.Close()
 
@@ -144,7 +144,7 @@ func TestDeliverUplinkMessage(t *testing.T) {
 		})
 
 		server := startMockServer(mux)
-		middleware := NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+		middleware := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 		middleware.BaseUrl = server.URL
 		defer server.Close()
 
@@ -171,7 +171,7 @@ func TestDeliverUplinkMessage(t *testing.T) {
 		})
 
 		server := startMockServer(mux)
-		middleware := NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+		middleware := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 		middleware.BaseUrl = server.URL
 		defer server.Close()
 
@@ -300,7 +300,7 @@ func TestResponseVariants(t *testing.T) {
 			})
 
 			server := startMockServer(mux)
-			middleware := NewLoracloudMiddleware(context.TODO(), "access_token", zap.NewExample())
+			middleware := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample())
 			middleware.BaseUrl = server.URL
 			defer server.Close()
 
@@ -434,5 +434,21 @@ func TestValidateContext(t *testing.T) {
 			assert.ErrorIs(t, err, tt.wantErr, "expected error to match")
 
 		})
+	}
+}
+
+func TestWithBaseUrl(t *testing.T) {
+	// Create a LoracloudClient with a default BaseUrl
+	client := LoracloudClient{
+		BaseUrl: "https://default.url",
+	}
+
+	// Use WithBaseUrl to set a new BaseUrl
+	newUrl := "https://custom.url"
+	option := WithBaseUrl(newUrl)
+	option(&client)
+
+	if client.BaseUrl != newUrl {
+		t.Errorf("expected BaseUrl to be %q, got %q", newUrl, client.BaseUrl)
 	}
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `LoracloudMiddleware` implementation, replacing it with a more flexible `LoracloudClient`. Additionally, the metrics definitions for AWS solvers have been refactored into a separate file. These updates aim to enhance modularity and maintainability across the codebase.

### Refactoring of `LoracloudMiddleware` to `LoracloudClient`:

* [`pkg/solver/loracloud/loracloud.go`](diffhunk://#diff-4f7561d77121dad700a69167bda78e010bf675a2fefddfd0eda7ae85cb816db1L19-R51): Renamed `LoracloudMiddleware` to `LoracloudClient`, added support for customizable options like `WithBaseUrl`, and updated method signatures to reflect the new client structure. [[1]](diffhunk://#diff-4f7561d77121dad700a69167bda78e010bf675a2fefddfd0eda7ae85cb816db1L19-R51) [[2]](diffhunk://#diff-4f7561d77121dad700a69167bda78e010bf675a2fefddfd0eda7ae85cb816db1L66-R84) [[3]](diffhunk://#diff-4f7561d77121dad700a69167bda78e010bf675a2fefddfd0eda7ae85cb816db1L97-R115) [[4]](diffhunk://#diff-4f7561d77121dad700a69167bda78e010bf675a2fefddfd0eda7ae85cb816db1L155-R173)
* `cmd/http.go`, `cmd/smartlabel.go`, `cmd/tagxl.go`: Updated references to use `loracloud.NewLoracloudClient` instead of `loracloud.NewLoracloudMiddleware`. [[1]](diffhunk://#diff-79ed4f0284d821696685c6a36c55837fa5549156b83243c954205144be62b469L96-R96) [[2]](diffhunk://#diff-196ee4946c54fa637d0497f9ff2c4cbbe05106d3e200860a0db4158d7d963e25L53-R53) [[3]](diffhunk://#diff-ca3c4c0e0043e11c0191634a9321a82aaea527e455e2fc46905384a841c9f125L53-R53)
* `pkg/decoder/smartlabel/v1/decoder_test.go`, `pkg/decoder/tagxl/v1/decoder_test.go`: Adjusted test cases to use `LoracloudClient` instead of `LoracloudMiddleware`. [[1]](diffhunk://#diff-e3356138721ae5362686ca1de85c12e65c0eeabed842815aa13bcc303dacb149L60-R60) [[2]](diffhunk://#diff-e3356138721ae5362686ca1de85c12e65c0eeabed842815aa13bcc303dacb149L510-R510) [[3]](diffhunk://#diff-6889fdede49e89057f804d6cfe03ca938059d94c2eb1e4dce02699783887422aL62-R62) [[4]](diffhunk://#diff-6889fdede49e89057f804d6cfe03ca938059d94c2eb1e4dce02699783887422aL648-R648)
* [`pkg/solver/loracloud/loracloud_test.go`](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318L34-R34): Updated all tests to reflect the new `LoracloudClient` implementation and added a test for the `WithBaseUrl` option. [[1]](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318L34-R34) [[2]](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318L96-R96) [[3]](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318L120-R120) [[4]](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318L147-R147) [[5]](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318L174-R174) [[6]](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318L303-R303) [[7]](diffhunk://#diff-7bc1882475e54e4f9a60168032ef599b4a60ccb30b920fe84a8d326f9b336318R439-R454)

### Metrics refactoring for AWS solvers:

* [`pkg/solver/aws/aws.go`](diffhunk://#diff-85553887220042bf2235f1886ac87bdd9854fd6eb2402d76e7a04c9dabf71343L13-L52): Removed inline Prometheus metrics definitions from this file.
* [`pkg/solver/aws/metrics.go`](diffhunk://#diff-fd3f91669e164ea19dca25e84f35d747ebbccbd8d4b105d12ad9c5c03d2fa2b9R1-R39): Created a new file to house Prometheus metrics definitions for AWS solvers, improving modularity.… command files and tests; add metrics and loracloud implementation