### PR TITLE
fix(tagsl): combined messages also expose ttf pdop and satellites

### DIFF
--- a/pkg/decoder/tagsl/v1/port150.go
+++ b/pkg/decoder/tagsl/v1/port150.go
@@ -119,7 +119,7 @@ func (p Port150Payload) GetAccuracy() *float64 {
 }
 
 func (p Port150Payload) GetTTF() *time.Duration {
-	return nil
+	return &p.TTF
 }
 
 func (p Port150Payload) GetPDOP() *float64 {

--- a/pkg/decoder/tagsl/v1/port151.go
+++ b/pkg/decoder/tagsl/v1/port151.go
@@ -111,15 +111,15 @@ func (p Port151Payload) GetAccuracy() *float64 {
 }
 
 func (p Port151Payload) GetTTF() *time.Duration {
-	return nil
+	return &p.TTF
 }
 
 func (p Port151Payload) GetPDOP() *float64 {
-	return nil
+	return &p.PDOP
 }
 
 func (p Port151Payload) GetSatellites() *uint8 {
-	return nil
+	return &p.Satellites
 }
 
 func (p Port151Payload) GetBatteryVoltage() float64 {

--- a/pkg/decoder/tagsl/v1/port50.go
+++ b/pkg/decoder/tagsl/v1/port50.go
@@ -116,7 +116,7 @@ func (p Port50Payload) GetAccuracy() *float64 {
 }
 
 func (p Port50Payload) GetTTF() *time.Duration {
-	return nil
+	return &p.TTF
 }
 
 func (p Port50Payload) GetPDOP() *float64 {

--- a/pkg/decoder/tagsl/v1/port51.go
+++ b/pkg/decoder/tagsl/v1/port51.go
@@ -124,15 +124,15 @@ func (p Port51Payload) GetAccuracy() *float64 {
 }
 
 func (p Port51Payload) GetTTF() *time.Duration {
-	return nil
+	return &p.TTF
 }
 
 func (p Port51Payload) GetPDOP() *float64 {
-	return nil
+	return &p.PDOP
 }
 
 func (p Port51Payload) GetSatellites() *uint8 {
-	return nil
+	return &p.Satellites
 }
 
 func (p Port51Payload) GetBatteryVoltage() float64 {


### PR DESCRIPTION
We are throwing away information by not exposing those metrics via features. 
Probably a copa pasta error which no one has noticed since @michaelbeutler did the initial implementation. 