### PR TITLE
Add custom .yamllint configuration and update CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,43 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
-          # Enable caching for Go modules
+          go-version: 1.24
           cache: true
-          # Optional: Specify a cache-dependency path if your go.mod/go.sum are not at the root
-          # cache-dependency-path: go.sum
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install detect-secrets yamllint
+
+      - name: go mod tidy check
+        run: |
+          cp go.mod go.mod.prev
+          cp go.sum go.sum.prev
+          go mod tidy
+          diff -u go.mod.prev go.mod || (echo "::error file=go.mod::Run 'go mod tidy' and commit changes."; exit 1)
+          diff -u go.sum.prev go.sum || (echo "::error file=go.sum::Run 'go mod tidy' and commit changes."; exit 1)
+
+      - name: go fmt (no diffs allowed)
+        run: |
+          CHANGED=$(gofmt -s -l . || true)
+          if [ -n "$CHANGED" ]; then
+            echo "::error ::Run 'gofmt -s -w .' to format:"
+            echo "$CHANGED"
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: staticcheck
+        run: $(go env GOPATH)/bin/staticcheck ./...
 
       - name: Lint
         uses: golangci/golangci-lint-action@v6
@@ -34,6 +66,30 @@ jobs:
 
       - name: Check Prometheus metrics
         run: make check-metrics
+
+      - name: Run yamllint
+        run: yamllint .
+
+      - name: Check for uncommitted changes
+        run: |
+          git diff --exit-code || (echo "::error::Generated code is not up to date. Run 'make generate' and commit changes."; exit 1)
+
+      - name: Detect secrets
+        run: |
+          echo "🔍 Scanning for secrets..."
+          if command -v detect-secrets >/dev/null 2>&1; then
+            detect-secrets scan --baseline .secrets.baseline --all-files || echo "Secret detection completed with findings"
+            if [ -f ".secrets.baseline" ]; then
+              detect-secrets audit .secrets.baseline --statistics || echo "Baseline audit completed"
+            fi
+          else
+            echo "detect-secrets not available, skipping secret scan (basic validation will still run)"
+          fi
+
+      - name: Secret Scanning with TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unknown
 
   test-coverage:
     name: Test & Coverage 🧪
@@ -50,11 +106,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
-          # Enable caching for Go modules
+          go-version: 1.24
           cache: true
-          # Optional: Specify a cache-dependency path if your go.mod/go.sum are not at the root
-          # cache-dependency-path: go.sum
 
       - name: Generate test coverage
         # No explicit 'go mod download' needed if tests directly use modules,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,11 +87,6 @@ jobs:
             echo "detect-secrets not available, skipping secret scan (basic validation will still run)"
           fi
 
-      - name: Secret Scanning with TruffleHog
-        uses: trufflesecurity/trufflehog@main
-        with:
-          extra_args: --results=verified,unknown
-
   test-coverage:
     name: Test & Coverage 🧪
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,8 +111,6 @@ jobs:
           cache: true
 
       - name: Generate test coverage
-        # No explicit 'go mod download' needed if tests directly use modules,
-        # as the 'go test' command will use the cached modules.
         run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
       - "**.go"
       - "**.md"
       - "**.mod"
+      - ".github/workflows/**.yaml"
 
 jobs:
   lint-and-format:

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@
 
 ^decoder$
 dist/
-.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.0
+    hooks:
+      - id: go-fmt
+      - id: go-imports
+      - id: no-go-testing
+      - id: golangci-lint
+      - id: go-unit-tests
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: [--config-file=.yamllint]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1974 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "README.md",
+        "hashed_secret": "4d56211d01d64fdacf65fc1caef3a12237dbd30a",
+        "is_verified": false,
+        "line_number": 97,
+        "is_secret": false
+      }
+    ],
+    "cmd/http_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "cmd/http_test.go",
+        "hashed_secret": "4d56211d01d64fdacf65fc1caef3a12237dbd30a",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "cmd/http_test.go",
+        "hashed_secret": "44bf1f7c931a410503db9759de7d3758c84c6e0f",
+        "is_verified": false,
+        "line_number": 165,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "cmd/http_test.go",
+        "hashed_secret": "116acfdb39846d90401e995a76003aba8b664352",
+        "is_verified": false,
+        "line_number": 208,
+        "is_secret": false
+      }
+    ],
+    "pkg/common/helpers_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/common/helpers_test.go",
+        "hashed_secret": "4d56211d01d64fdacf65fc1caef3a12237dbd30a",
+        "is_verified": false,
+        "line_number": 88,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/common/helpers_test.go",
+        "hashed_secret": "07621926332a7aa61d6240420968fff07444731a",
+        "is_verified": false,
+        "line_number": 104,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/common/helpers_test.go",
+        "hashed_secret": "687acbd024cc117b6d625c7f2c139a081537323f",
+        "is_verified": false,
+        "line_number": 110,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/nomadxs/v1/decoder_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "218f9326549a5e0ec8a072eeb758272a96774874",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "a59ad97f3bbbb4e60da4510a9b2a8616f2368785",
+        "is_verified": false,
+        "line_number": 51,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "ad093615db8d44ced68edd64572e0f45cef791f0",
+        "is_verified": false,
+        "line_number": 83,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "6892b5e88d93ed1713d8c77ef7d1daa72d76ce61",
+        "is_verified": false,
+        "line_number": 107,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "3fd6318be4ad86b004c399338c8bbce579f2bf99",
+        "is_verified": false,
+        "line_number": 221,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "07f1d11e4cf3ca31fdbf70a4a84ea9ab6ef6fae9",
+        "is_verified": false,
+        "line_number": 226,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "21c19a2d5a95036e9150bec34d76b3dc8fa389c3",
+        "is_verified": false,
+        "line_number": 231,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "82378f805a7817ebf8382eaac06877e4a26decd9",
+        "is_verified": false,
+        "line_number": 236,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "d2f7046d13f23d7c940891a6cd6f702a444712e4",
+        "is_verified": false,
+        "line_number": 241,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "7d937ed124a6721f46742b87ae13f5175dc737d6",
+        "is_verified": false,
+        "line_number": 246,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "bd4967e4a46d45e53cb5d2e240f1250110f716eb",
+        "is_verified": false,
+        "line_number": 251,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "5a2fb47e02909b408e43d6463ddfd3df3cb9e307",
+        "is_verified": false,
+        "line_number": 256,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "f9e132ead483a20cc19e52832c1824b139caf6b1",
+        "is_verified": false,
+        "line_number": 261,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/nomadxs/v1/decoder_test.go",
+        "hashed_secret": "43f3b28c71181026691d3d851d3398e41ae205b0",
+        "is_verified": false,
+        "line_number": 266,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/smartlabel/v1/decoder_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "2969e12a864a2091be4082d99c1767a6d225ef9f",
+        "is_verified": false,
+        "line_number": 170,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "18911f680f30a3d441a7314a5f4131ccdf5a291d",
+        "is_verified": false,
+        "line_number": 193,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "03799cbbbde9a26987fc61ee9d1c7607efa5b6c3",
+        "is_verified": false,
+        "line_number": 216,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "d85e5644e91feb126f202af26abefd4aadde571e",
+        "is_verified": false,
+        "line_number": 239,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "9db4104f44fd40f26bce7072ad15bc10f1e833d6",
+        "is_verified": false,
+        "line_number": 259,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "517accb9519da7da9ae0f3ee9eac83543169ee17",
+        "is_verified": false,
+        "line_number": 269,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "32179884041e9ddc27e1c5e0e45ccc6e81637d65",
+        "is_verified": false,
+        "line_number": 279,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "07cb4aff970c7271688f1e8eaf214a516d3970e3",
+        "is_verified": false,
+        "line_number": 299,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "bc4afa2f3630480ca72a32c5c8421b39f3ce1a71",
+        "is_verified": false,
+        "line_number": 332,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "395900609a0d94e6b75d0f0cb6b647d1d554c442",
+        "is_verified": false,
+        "line_number": 343,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "81de30f2e09afabf90f74a4addd1ddbc354277d4",
+        "is_verified": false,
+        "line_number": 356,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "a158f37d59e2f1ea505e92294149581814a5ffe3",
+        "is_verified": false,
+        "line_number": 373,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/decoder_test.go",
+        "hashed_secret": "884f72cf02528dcd37a031e2af8575273d4394e2",
+        "is_verified": false,
+        "line_number": 500,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/smartlabel/v1/input.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/input.json",
+        "hashed_secret": "32179884041e9ddc27e1c5e0e45ccc6e81637d65",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/smartlabel/v1/response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/smartlabel/v1/response.json",
+        "hashed_secret": "85afdb46df38392f5aa3b520d74e4a40f6904964",
+        "is_verified": false,
+        "line_number": 36,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/tagsl/v1/decoder_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4d56211d01d64fdacf65fc1caef3a12237dbd30a",
+        "is_verified": false,
+        "line_number": 26,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "aee9b5963d186701a30e5f458d0ae7bd92440623",
+        "is_verified": false,
+        "line_number": 64,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "76bceaf8e015ef80ad2e4f13f60f6138adf893fb",
+        "is_verified": false,
+        "line_number": 84,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "bd559560db885a0a6be3236fc11d8a3d1ba06e4f",
+        "is_verified": false,
+        "line_number": 181,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "880b7b2e83776fc4fce15f888f50c9f639652e36",
+        "is_verified": false,
+        "line_number": 192,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "f9af07356d79806c477386122315490bae72aab6",
+        "is_verified": false,
+        "line_number": 203,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "65932e64fcc5ff9a73e0caad1a106670d6adf400",
+        "is_verified": false,
+        "line_number": 218,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "b5155189d0445febca625c6443a355297d37f7fe",
+        "is_verified": false,
+        "line_number": 322,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "45dcdf72ad07c05ecf291970881d4e4da4b045be",
+        "is_verified": false,
+        "line_number": 326,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "9efb937dc6fc6fed7cf6fbb07a13247438a0cb66",
+        "is_verified": false,
+        "line_number": 332,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "95ee7ce7785840997fca4c543af8f8e5ecad3e47",
+        "is_verified": false,
+        "line_number": 336,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "2aed0433683ce7e167f5d1352ff13ef86b8482d2",
+        "is_verified": false,
+        "line_number": 346,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "15bdecc414877451c0ac5fb7010c119ad05c1341",
+        "is_verified": false,
+        "line_number": 350,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "5c311f41abeb1f8d14d09e891d810baf89b2a622",
+        "is_verified": false,
+        "line_number": 364,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "f5a1f8254f974172e74560ab8eb3151ef17beb30",
+        "is_verified": false,
+        "line_number": 387,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "58e1b13efdd15138317388b2f77415d1efe74239",
+        "is_verified": false,
+        "line_number": 432,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "db867a42517a4706bf81caaec0f5605a1ea3e34e",
+        "is_verified": false,
+        "line_number": 455,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4034f222358e7a6eabf4c57fd8d2eceec1cff41a",
+        "is_verified": false,
+        "line_number": 479,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "0e262d812b6ca1565c5015c83c491496af7793bb",
+        "is_verified": false,
+        "line_number": 492,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "be729162560f0e9701f705cd1614ed78e008a658",
+        "is_verified": false,
+        "line_number": 505,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4dcdff0bce20bc74c7e0f59f9ead20e3c77096de",
+        "is_verified": false,
+        "line_number": 520,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "e96414e2ceb73830ebba40a14d9e0bea29858eb0",
+        "is_verified": false,
+        "line_number": 551,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "b5950857a05765aaec2390c6fb6e6d178fde38ec",
+        "is_verified": false,
+        "line_number": 562,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "cb7e80b2f321795df274f509805b20ed3c6751d4",
+        "is_verified": false,
+        "line_number": 576,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "bba62a3bbbeaf8bed3956c6c192236d906751da1",
+        "is_verified": false,
+        "line_number": 591,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "31a99520b7eba697c7444952c3c2371989f5d302",
+        "is_verified": false,
+        "line_number": 612,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "3dd088d254d2263b613e999eb38c2d082d060b39",
+        "is_verified": false,
+        "line_number": 687,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "83ab17724e29464aa19eb62a3ec320f693c4199f",
+        "is_verified": false,
+        "line_number": 709,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "c95a61ad80326b82fa49aad0fcf425a3d7ead2b7",
+        "is_verified": false,
+        "line_number": 729,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "22b1e759001ce9defffd8fbacead6a71d5f7f644",
+        "is_verified": false,
+        "line_number": 773,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
+        "is_verified": false,
+        "line_number": 783,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "a2eff15d0e3abb066344af61ca597e5575312b7d",
+        "is_verified": false,
+        "line_number": 804,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "9d4748082c8c11aff4001b76aba0b30460ce1228",
+        "is_verified": false,
+        "line_number": 823,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "2dd04c4f36f29f0c2107a88d67667be9bad5da0b",
+        "is_verified": false,
+        "line_number": 837,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "fc3a44706f4ed1d7561d64278ce5c722589b22ab",
+        "is_verified": false,
+        "line_number": 849,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "feeecd63c147195b4105830d21993fece572fe7b",
+        "is_verified": false,
+        "line_number": 869,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "8a6c8572b99d521eef6b4a84df768e5e139ea5e4",
+        "is_verified": false,
+        "line_number": 889,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "619b165cf1665fc690f71c9021635667c1a9d925",
+        "is_verified": false,
+        "line_number": 928,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "2f8702eac3aa3dcb3ce596ee88152f0c448fdc71",
+        "is_verified": false,
+        "line_number": 949,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "97d57d0610498aa317e06c23f304e6f8784112d9",
+        "is_verified": false,
+        "line_number": 969,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "5142cefc1dc327827e8f7ae7ba801bf970c7f524",
+        "is_verified": false,
+        "line_number": 989,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "07325f0b872a1751c51a06497a8c112430cd0ea5",
+        "is_verified": false,
+        "line_number": 1011,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "52cfed0797142f778d87452cc415db81143ac365",
+        "is_verified": false,
+        "line_number": 1034,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "82b0c946a02c6653237a78c65b906791530b3ad4",
+        "is_verified": false,
+        "line_number": 1058,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "fbc4795ed89ae9cadb6fe7b23fb911b98a50573d",
+        "is_verified": false,
+        "line_number": 1072,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "16fb1ef9606e1f3b0a4097bfa5084ff0c73adc0e",
+        "is_verified": false,
+        "line_number": 1086,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4fbd145a80b3844b4c0fa1891018f112d8a4cfd9",
+        "is_verified": false,
+        "line_number": 1104,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "5148a3d442475f3690c83686f1b86d3fb1ddf53f",
+        "is_verified": false,
+        "line_number": 1121,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "029b2bca56c1b3b4fa7976dcbbbadda7604ea46a",
+        "is_verified": false,
+        "line_number": 1135,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "b39091d2985983c65671abf5da4f358ca3204aac",
+        "is_verified": false,
+        "line_number": 1154,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "11c8b7a2a2a699880d93a67b89acc6284906956d",
+        "is_verified": false,
+        "line_number": 1179,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "626f9f8b8aa407b42e820cc313acd6db3295e9cc",
+        "is_verified": false,
+        "line_number": 1204,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "bc2ac0fe49674b7457213dc8e7dc417f7ef69469",
+        "is_verified": false,
+        "line_number": 1217,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4c5ebbbf2ba50eade3687c8fa6cc9891a572a97b",
+        "is_verified": false,
+        "line_number": 1254,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "22d0e5481e87ef019ec6e6e25e7aed04ba1eebce",
+        "is_verified": false,
+        "line_number": 1280,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "070a0884b834873dfa21639922378396a9e34661",
+        "is_verified": false,
+        "line_number": 1318,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "46b3cefa3082f56d07ac25f0d4c2ffcf6ed69b28",
+        "is_verified": false,
+        "line_number": 1337,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "d9e77b9592259eb596b50df9eb7ed9d2c643086d",
+        "is_verified": false,
+        "line_number": 1352,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "8a7e84e02bd69e1a76cf2a493fb63980ac1062fb",
+        "is_verified": false,
+        "line_number": 1360,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "f7e47b71351261ac247b71cab2cbf38b1b3333c6",
+        "is_verified": false,
+        "line_number": 1387,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "d9a081ac8ab847e1a2081b0fb6e0e7c08ba0d2eb",
+        "is_verified": false,
+        "line_number": 1415,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4dc873cc09613e992ebe16bc31121bc224073521",
+        "is_verified": false,
+        "line_number": 1457,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "78dbc4eafb03113e02d0119c5405be293e34a116",
+        "is_verified": false,
+        "line_number": 1509,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "c0d70edfee3d9fe4436b75dab4321b46c1ec678d",
+        "is_verified": false,
+        "line_number": 1519,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "60a5e86e9110d68b06c4781b12da9902abe94a63",
+        "is_verified": false,
+        "line_number": 1529,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "ce09bde1b0182afd6bc649891b02786b4afd6968",
+        "is_verified": false,
+        "line_number": 1549,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "0c6e1135f0868600daecede0164f01f7b2fb9cc6",
+        "is_verified": false,
+        "line_number": 1569,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "ecba67730af51c1fe53055da71e66c4b18bec47d",
+        "is_verified": false,
+        "line_number": 1616,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "243124ba42ea803ccaf83f33c46cd88e1bf8ad6f",
+        "is_verified": false,
+        "line_number": 1621,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "e680eb6ac0887cbf8e323d968e7bbfdb6e5a408f",
+        "is_verified": false,
+        "line_number": 1626,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "d354f0f33e04038f12672f9f9d2454d869f5ec5c",
+        "is_verified": false,
+        "line_number": 1631,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "8418b8a11e15da64f413edf42370d697fefae446",
+        "is_verified": false,
+        "line_number": 1636,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "845b0d08338a9355922067acc1423a2b4b7fe364",
+        "is_verified": false,
+        "line_number": 1641,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "1747d5a1c2efc5371fb745304ad69886652cfa6c",
+        "is_verified": false,
+        "line_number": 1646,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "410383290d2c4621c71350224217673a2eacf916",
+        "is_verified": false,
+        "line_number": 1656,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "8136636c3e1320795f72ba46dfd58d38e13ff8e6",
+        "is_verified": false,
+        "line_number": 1661,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "3fa0dd7c64ebebf981f4b92a292eee37664106e6",
+        "is_verified": false,
+        "line_number": 1666,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "c4ede4aa512277d5913681c850e094ab3d224002",
+        "is_verified": false,
+        "line_number": 1671,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "dfe09dd42d5ab49ee9abeca2c87a6633cdbd8c72",
+        "is_verified": false,
+        "line_number": 1676,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "8e3af6a1ed46b78a31aa1197dba812bf9c3451c5",
+        "is_verified": false,
+        "line_number": 1681,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "6a0f25adc054155a674e91a7f78e81cf31c74bf1",
+        "is_verified": false,
+        "line_number": 1701,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "9eaa692c674262fc8cfb06580b513fbc5a93134e",
+        "is_verified": false,
+        "line_number": 1706,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "abc00733eb25276faac611e31dfe95d708870e03",
+        "is_verified": false,
+        "line_number": 1711,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "fd1eb27a5fbba10b5b4ff0bc407d44ac1b24167e",
+        "is_verified": false,
+        "line_number": 1716,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "a2ae827d799199d3d1baa7d393e5c3e31c9bc8e6",
+        "is_verified": false,
+        "line_number": 1721,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "0c91c5cb9d56cc0171a991e56bc6427daacd92a1",
+        "is_verified": false,
+        "line_number": 1726,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "30a0b09e7a4e94e87f2a9f4cf7f7dac4d6fc7ab1",
+        "is_verified": false,
+        "line_number": 1731,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "f5d5837942ad0336f9eff696554a6090cea37c91",
+        "is_verified": false,
+        "line_number": 1736,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "82728cf0efb858a97903276062482f8f397d0e91",
+        "is_verified": false,
+        "line_number": 1741,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "144d1655f91880a3592b8e38153a120fec994302",
+        "is_verified": false,
+        "line_number": 1746,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "ec3ee07679aeb94dee708e6afe0bffa59b968f6e",
+        "is_verified": false,
+        "line_number": 1751,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4972105006e0b08837d0f184732f7a06aba70302",
+        "is_verified": false,
+        "line_number": 1756,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "d41b66bd74ac59e64dcc8832eabda42f62b6e180",
+        "is_verified": false,
+        "line_number": 1761,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "50cbc40d6ab2dc9f1ec48293fa0ba6f79dc96835",
+        "is_verified": false,
+        "line_number": 1766,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "4ead03bc45421378874317365e39aa873eb2b8bc",
+        "is_verified": false,
+        "line_number": 1771,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "0bc8f460e7c2185b28ff8b00d32e4a0d9740a2e5",
+        "is_verified": false,
+        "line_number": 1776,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "6f4dcdcec757c2894f45b29e43de6b31463d10d5",
+        "is_verified": false,
+        "line_number": 1781,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "1cc4ebae8c979ce47ebf1057dd8bec8e0f39e805",
+        "is_verified": false,
+        "line_number": 1786,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "b633a7193242cf7a0d95933db10b1b3c57b1d381",
+        "is_verified": false,
+        "line_number": 1791,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "78d8d4885ccf3358941670a153a54bcb89ab32df",
+        "is_verified": false,
+        "line_number": 1796,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "e51337283ba5632b9366cf0ed4a5f5a91a0651b9",
+        "is_verified": false,
+        "line_number": 1801,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "e0470066812b6eeb9427ea31d9ee31f62da62e85",
+        "is_verified": false,
+        "line_number": 1806,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "9c46efd9a7f86b5259f8414c58d40340b5842a04",
+        "is_verified": false,
+        "line_number": 1811,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "b77f33e98e53c50c42f934caf97a8886b89ee13f",
+        "is_verified": false,
+        "line_number": 1816,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "2e1dfca6cbf9721a8bf013e00b46314bdca4bb6c",
+        "is_verified": false,
+        "line_number": 1821,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "6a75920be2331eb84c05a8c6816047a9130a39d2",
+        "is_verified": false,
+        "line_number": 1826,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "f7f06b05f4cd54c416acc62fdb84ac721dcb75c9",
+        "is_verified": false,
+        "line_number": 1831,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "a067ac4b430ab07dda6b76915143921e9c063960",
+        "is_verified": false,
+        "line_number": 1836,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "5ad7464d84954552692705df853c569a0e062579",
+        "is_verified": false,
+        "line_number": 1841,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "5634e40f52daaabfd9eaea0ca9d227913b369136",
+        "is_verified": false,
+        "line_number": 1909,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "c95e5ca7aa2290267fcf16e603343d109e80ee53",
+        "is_verified": false,
+        "line_number": 1933,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "44bf1f7c931a410503db9759de7d3758c84c6e0f",
+        "is_verified": false,
+        "line_number": 1952,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "116acfdb39846d90401e995a76003aba8b664352",
+        "is_verified": false,
+        "line_number": 1960,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "b4b606d84bd119aae19310a43b203c063f6df405",
+        "is_verified": false,
+        "line_number": 1976,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "de693c33aa7dc9f5cc5665454f8e30c070511634",
+        "is_verified": false,
+        "line_number": 2053,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "ee7bfc7e008cd63d0db92515aa217e47780471d6",
+        "is_verified": false,
+        "line_number": 2082,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "b40059438caac64f210382b0756b5e0fbcae100d",
+        "is_verified": false,
+        "line_number": 2098,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "917e65661cd4d85ccfde96243b052494f160b704",
+        "is_verified": false,
+        "line_number": 2106,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "32fe17aa9743d82d59af5c8081f44ac1cdf5a78c",
+        "is_verified": false,
+        "line_number": 2114,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagsl/v1/decoder_test.go",
+        "hashed_secret": "d76d7d922e691ced5b77d86c9c4282866a26f89f",
+        "is_verified": false,
+        "line_number": 2355,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/tagxl/v1/decoder_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "ed2b7805cbf0feec0ab81d143f4df1125c57bf3f",
+        "is_verified": false,
+        "line_number": 107,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "555917d2175ab1600c6cd926d255df6ad502febc",
+        "is_verified": false,
+        "line_number": 220,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "6c45c0c1b339a7891ba24bf33ef5b40b040a86a0",
+        "is_verified": false,
+        "line_number": 240,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "32179884041e9ddc27e1c5e0e45ccc6e81637d65",
+        "is_verified": false,
+        "line_number": 330,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "55472b68d8a8560add30831739dd3552e63d5b33",
+        "is_verified": false,
+        "line_number": 357,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "463609dcc13b7b90fcf29ca237191ad5bf977c46",
+        "is_verified": false,
+        "line_number": 366,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "4c35a80282e5237761aeb3b9b2c8d422b16df653",
+        "is_verified": false,
+        "line_number": 376,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "5bcf7c2f08e382a84f0a78f1c6aa91f711806aa8",
+        "is_verified": false,
+        "line_number": 387,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "0560cb6af09786d2305b91018ca587c93c0d7dbd",
+        "is_verified": false,
+        "line_number": 399,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "66cd8eba7181b16377a615d793be286a3aacb087",
+        "is_verified": false,
+        "line_number": 407,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "a6c92fb0cd83e9a6f6f2bd5bfdb1a297dfe7a502",
+        "is_verified": false,
+        "line_number": 417,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "c0e35b955de71e6fe09016adf1216ed73f1d7a8b",
+        "is_verified": false,
+        "line_number": 429,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "5a0861255e90d61193afbc62ee5b7924739d1b54",
+        "is_verified": false,
+        "line_number": 443,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "516dead2735f9bcd1eced3f678aa6dbb0ed87c86",
+        "is_verified": false,
+        "line_number": 631,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/decoder_test.go",
+        "hashed_secret": "884f72cf02528dcd37a031e2af8575273d4394e2",
+        "is_verified": false,
+        "line_number": 643,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/tagxl/v1/input.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/input.json",
+        "hashed_secret": "32179884041e9ddc27e1c5e0e45ccc6e81637d65",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      }
+    ],
+    "pkg/decoder/tagxl/v1/response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/decoder/tagxl/v1/response.json",
+        "hashed_secret": "85afdb46df38392f5aa3b520d74e4a40f6904964",
+        "is_verified": false,
+        "line_number": 36,
+        "is_secret": false
+      }
+    ],
+    "pkg/encoder/nomadxs/v1/encoder_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/nomadxs/v1/encoder_test.go",
+        "hashed_secret": "3855ff9d1832eb080b5ea5205b4b99251317e4cb",
+        "is_verified": false,
+        "line_number": 40,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/nomadxs/v1/encoder_test.go",
+        "hashed_secret": "764509e5f48f7c9f81a257839b5c5e1036e5f601",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/nomadxs/v1/encoder_test.go",
+        "hashed_secret": "6bc0146b932505c8fce60c3a019bc0d57a974cf1",
+        "is_verified": false,
+        "line_number": 86,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/nomadxs/v1/encoder_test.go",
+        "hashed_secret": "4635b54625c0e934de91c20285267d61f8f519db",
+        "is_verified": false,
+        "line_number": 109,
+        "is_secret": false
+      }
+    ],
+    "pkg/encoder/smartlabel/v1/encoder_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/smartlabel/v1/encoder_test.go",
+        "hashed_secret": "96e2fa89d5aed98d8ddc4a7e096e26ec7affb56b",
+        "is_verified": false,
+        "line_number": 100,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/smartlabel/v1/encoder_test.go",
+        "hashed_secret": "87eba1e4705b07dd7b56752c6b132675ff140acb",
+        "is_verified": false,
+        "line_number": 137,
+        "is_secret": false
+      }
+    ],
+    "pkg/encoder/tagsl/v1/encoder_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "8aa655577635c0111d8ef9baf1940cd0220f5f7a",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "3048c1f6138c0624556771c5e9221deabbb9bb56",
+        "is_verified": false,
+        "line_number": 49,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "6f8f943dde4d7e0c9c0bd0c5a139f28e68f57c58",
+        "is_verified": false,
+        "line_number": 96,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "7b622b85c46abbfaf179676865a48fc9dd6aa755",
+        "is_verified": false,
+        "line_number": 100,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "b2ad7468b046d5af10e9c2a7bc9bec48e0afdbeb",
+        "is_verified": false,
+        "line_number": 111,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "16cf9dd541cc0d3c05fe8bdb9f21b323fa48119f",
+        "is_verified": false,
+        "line_number": 124,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "a5f1d0a3bc6845395d5b09761aab8b79cb9f710c",
+        "is_verified": false,
+        "line_number": 139,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "700fc3487752ea604d61b07683d04c1cc55cfbda",
+        "is_verified": false,
+        "line_number": 156,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "dfaa0650875ef14a70c344e0148b42db96a3b826",
+        "is_verified": false,
+        "line_number": 175,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "b29bbe65508c8f4adb7b056a2853b88bf3bebcba",
+        "is_verified": false,
+        "line_number": 196,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "9b517cdb2b0a9f113eec968c7812b5586a71777a",
+        "is_verified": false,
+        "line_number": 216,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "1bbd31d965434aae5f4b149099a392b84a9628d4",
+        "is_verified": false,
+        "line_number": 220,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "2fd43faca100e94fb41f56f64d95a1287950afc6",
+        "is_verified": false,
+        "line_number": 232,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "a53c8539efbe60b7c7a3b617578935487cd2ccf7",
+        "is_verified": false,
+        "line_number": 246,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "5a19df446db91f41a36a77a08bc3882d4fc9151d",
+        "is_verified": false,
+        "line_number": 262,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "cffa250ba5535cec809c1791f0dc44c6de30469f",
+        "is_verified": false,
+        "line_number": 280,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "523d8770094449aaf7b539a619aed044ee1c69c7",
+        "is_verified": false,
+        "line_number": 300,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "5424dcbc6f1043b9a1fcfdbe02462f99a1b9d36b",
+        "is_verified": false,
+        "line_number": 315,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "cea2b9a520af68a878242460551ce974a6a6406f",
+        "is_verified": false,
+        "line_number": 330,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "a702c2c1e5c0eae0d28e07034098dfaeaf3a8686",
+        "is_verified": false,
+        "line_number": 345,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "4b94629eee78fddc1117f1289b49521f487cf4f1",
+        "is_verified": false,
+        "line_number": 360,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "57af8e1340f7bb0766b6538515a9d121255f6a7a",
+        "is_verified": false,
+        "line_number": 387,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "735b83d9b7d1bda9defc5b0a8f5a9d8bfac05dfd",
+        "is_verified": false,
+        "line_number": 391,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "233df4d0d3625b116ea7903270d64b882167f2c6",
+        "is_verified": false,
+        "line_number": 408,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "ec56e9970fb77b2f023f6b77c89ced7ee1f2d91b",
+        "is_verified": false,
+        "line_number": 427,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "d71bb44ee948f860502b7d32a2e2bca8039df7ee",
+        "is_verified": false,
+        "line_number": 448,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "71edee845d66812fa774248a9d75ae965afef7d5",
+        "is_verified": false,
+        "line_number": 465,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "18c045b874607274a5f88ae77db0d7ddc92ad59b",
+        "is_verified": false,
+        "line_number": 484,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "aa256d290dae26f1afd8b46339b20a788d50a6d1",
+        "is_verified": false,
+        "line_number": 505,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "b22951ddaa6879c05daf7367695b911cba73605f",
+        "is_verified": false,
+        "line_number": 528,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "45c2f04a34c854b4f5d7fcb0107f49719c493e94",
+        "is_verified": false,
+        "line_number": 539,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "16f903545b36a2e6af3ff2bd5fc31cca5a2c7c36",
+        "is_verified": false,
+        "line_number": 552,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "1b305d935061f260522cb6d86030004b037ad411",
+        "is_verified": false,
+        "line_number": 567,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "b3f7663551ae5bac73ac35adfb7d8baeca351672",
+        "is_verified": false,
+        "line_number": 584,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "cc5a23815a4ded17c6d583a933ae53c064fb8dae",
+        "is_verified": false,
+        "line_number": 603,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "7d49ee8289c9316454fcd24f786dfb14752a5f87",
+        "is_verified": false,
+        "line_number": 624,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "5d31ca43ca85f441739753ae8a20f6aae8a7686e",
+        "is_verified": false,
+        "line_number": 640,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "4b92412990e455a8b2b14bdaba8a054ff727fa21",
+        "is_verified": false,
+        "line_number": 656,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "cae771c3b29e43e7e307a0ed87888f20b5921b2b",
+        "is_verified": false,
+        "line_number": 672,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "9a15a601471e54a4e31abe24489661e9688a9b63",
+        "is_verified": false,
+        "line_number": 688,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "ca8e85d2c3e9f6934272b7e68e0830ce1283fd3c",
+        "is_verified": false,
+        "line_number": 809,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/encoder/tagsl/v1/encoder_test.go",
+        "hashed_secret": "dc496d565d617db2551a5b9c344d8b67f16b8a30",
+        "is_verified": false,
+        "line_number": 824,
+        "is_secret": false
+      }
+    ],
+    "pkg/solver/aws/aws_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/solver/aws/aws_test.go",
+        "hashed_secret": "40ac629780e89319e9600423a89a0d4e12cdd1e8",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/solver/aws/aws_test.go",
+        "hashed_secret": "232838a7a907736f5c1a2418cca2bc399b4c4e08",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": false
+      }
+    ],
+    "pkg/solver/loracloud/loracloud_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/solver/loracloud/loracloud_test.go",
+        "hashed_secret": "884f72cf02528dcd37a031e2af8575273d4394e2",
+        "is_verified": false,
+        "line_number": 228,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/solver/loracloud/loracloud_test.go",
+        "hashed_secret": "56a889aac5ddc1816be3e5604074cf3e50c70500",
+        "is_verified": false,
+        "line_number": 351,
+        "is_secret": false
+      }
+    ],
+    "test/tagsl_v1.hurl": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/tagsl_v1.hurl",
+        "hashed_secret": "4d56211d01d64fdacf65fc1caef3a12237dbd30a",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2025-09-04T19:34:13Z"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Install pre-commit hooks",
+      "type": "shell",
+      "command": "pre-commit install",
+      "runOptions": { "runOn": "folderOpen" },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,56 @@
+---
+extends: default
+
+ignore: |
+  .git/
+  openapi.patched.yaml
+  openapi.yaml
+
+rules:
+  # Allow longer lines for URLs and certain contexts
+  line-length:
+    max: 300
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+
+  # Be more flexible with indentation in some contexts
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+
+  # Allow truthy values like "on", "off" which are common in configs
+  truthy:
+    allowed-values: ['true', 'false', 'on', 'off']
+
+  # Don't require document start marker for every file
+  document-start: disable
+
+  # Allow empty values (common in Helm templates)
+  empty-values: disable
+
+  # Be more permissive with comments
+  comments:
+    min-spaces-from-content: 0
+  comments-indentation: disable
+
+  # Allow Helm template syntax with braces
+  braces:
+    max-spaces-inside: 1
+    min-spaces-inside: 0
+
+  # Allow different line endings (for templates)
+  new-line-at-end-of-file: disable
+
+  # Allow different line ending types (Windows/Unix)
+  new-lines: disable
+
+  # Allow empty lines at start of file
+  empty-lines:
+    max-start: 1
+    max: 2
+
+  # Be permissive with trailing spaces (common in editors)
+  trailing-spaces: disable
+
+  # Be permissive with comma spacing
+  commas: disable

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -12,20 +12,20 @@ spec:
         app: decoder
     spec:
       containers:
-      - name: decoder
-        image: ghcr.io/truvami/decoder:latest # WARNING: never use latest in production
-        command:
+        - name: decoder
+          image: ghcr.io/truvami/decoder:latest # WARNING: never use latest in production
+          command:
             - decoder
-        args:
-            - 'http'
-            - '--host'
-            - '0.0.0.0' # Listen on all interfaces
-            - '--port'
-            - '8080' # Listen on port 8080
-            - '-jd' # Enable JSON decoding and debugging
-        resources:
-          limits:
-            memory: "128Mi"
-            cpu: "500m"
-        ports:
-        - containerPort: 8080
+          args:
+            - "http"
+            - "--host"
+            - "0.0.0.0" # Listen on all interfaces
+            - "--port"
+            - "8080" # Listen on port 8080
+            - "-jd" # Enable JSON decoding and debugging
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          ports:
+            - containerPort: 8080

--- a/pkg/encoder/nomadxs/v1/encoder.go
+++ b/pkg/encoder/nomadxs/v1/encoder.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/truvami/decoder/pkg/common"
-	"github.com/truvami/decoder/pkg/decoder/nomadxs/v1"
+	nomadxs "github.com/truvami/decoder/pkg/decoder/nomadxs/v1"
 	"github.com/truvami/decoder/pkg/encoder"
 )
 

--- a/pkg/encoder/nomadxs/v1/encoder_test.go
+++ b/pkg/encoder/nomadxs/v1/encoder_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/truvami/decoder/pkg/common"
-	"github.com/truvami/decoder/pkg/decoder/nomadxs/v1"
+	nomadxs "github.com/truvami/decoder/pkg/decoder/nomadxs/v1"
 )
 
 func TestEncode(t *testing.T) {

--- a/pkg/encoder/smartlabel/v1/encoder.go
+++ b/pkg/encoder/smartlabel/v1/encoder.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/truvami/decoder/pkg/common"
-	"github.com/truvami/decoder/pkg/decoder/smartlabel/v1"
+	smartlabel "github.com/truvami/decoder/pkg/decoder/smartlabel/v1"
 	"github.com/truvami/decoder/pkg/encoder"
 )
 

--- a/pkg/encoder/smartlabel/v1/encoder_test.go
+++ b/pkg/encoder/smartlabel/v1/encoder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/truvami/decoder/pkg/common"
-	"github.com/truvami/decoder/pkg/decoder/smartlabel/v1"
+	smartlabel "github.com/truvami/decoder/pkg/decoder/smartlabel/v1"
 )
 
 func TestEncode(t *testing.T) {

--- a/pkg/encoder/tagsl/v1/encoder.go
+++ b/pkg/encoder/tagsl/v1/encoder.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/truvami/decoder/pkg/common"
-	"github.com/truvami/decoder/pkg/decoder/tagsl/v1"
+	tagsl "github.com/truvami/decoder/pkg/decoder/tagsl/v1"
 	"github.com/truvami/decoder/pkg/encoder"
 )
 

--- a/pkg/encoder/tagsl/v1/encoder_test.go
+++ b/pkg/encoder/tagsl/v1/encoder_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	helpers "github.com/truvami/decoder/pkg/common"
-	"github.com/truvami/decoder/pkg/decoder/tagsl/v1"
+	tagsl "github.com/truvami/decoder/pkg/decoder/tagsl/v1"
 )
 
 func TestEncode(t *testing.T) {

--- a/pkg/solver/loracloud/metrics.go
+++ b/pkg/solver/loracloud/metrics.go
@@ -9,21 +9,21 @@ var (
 	loracloudPositionEstimateNoCapturedAtSetCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "truvami_loracloud_position_estimate_no_captured_at_set_total",
 		Help: "The total number of position estimate responses where the captured at (UTC) timestamp is not set",
-	}, []string{"devEUI"})
+	}, []string{"devEui"})
 	loracloudPositionEstimateZeroCoordinatesSetCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "truvami_loracloud_position_estimate_zero_coordinates_set_total",
 		Help: "The total number of position estimate responses where the coordinates are set to 0",
-	}, []string{"devEUI"})
+	}, []string{"devEui"})
 	loracloudPositionEstimateNoCapturedAtSetWithValidCoordinatesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "truvami_loracloud_position_estimate_no_captured_at_set_with_valid_coordinates_total",
 		Help: "The total number of position estimate responses where the captured at (UTC) timestamp is not set and the coordinates are valid",
-	}, []string{"devEUI"})
+	}, []string{"devEui"})
 	loracloudPositionEstimateValidCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "truvami_loracloud_position_estimate_valid_total",
 		Help: "The total number of position estimate responses where the captured at (UTC) timestamp is set and the coordinates are valid",
-	}, []string{"devEUI"})
+	}, []string{"devEui"})
 	loracloudPositionEstimateInvalidCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "truvami_loracloud_position_estimate_invalid_total",
 		Help: "The total number of position estimate responses where the position resolution is invalid",
-	}, []string{"devEUI"})
+	}, []string{"devEui"})
 )


### PR DESCRIPTION
This pull request introduces several improvements to CI/CD workflows, code quality tooling, and minor codebase consistency updates. The main focus is on adding pre-commit hooks, secret detection, YAML linting, and enhancing the GitHub Actions workflow for better code hygiene and security. Additionally, there are minor refactors for import statements and metric label consistency.

**CI/CD and Code Quality Tooling**

* Added a `.pre-commit-config.yaml` file to set up pre-commit hooks for formatting, linting, YAML validation, Go code checks, and secret detection. This helps catch issues before code is committed.
* Introduced a `.vscode/tasks.json` task to automatically install pre-commit hooks when the project folder is opened in VS Code, streamlining developer setup.
* Added a `.yamllint` configuration file to enforce consistent YAML formatting, with rules tailored for the project's needs (e.g., line length, indentation, Helm template syntax).

**GitHub Actions Workflow Enhancements**

* Updated `.github/workflows/ci.yaml` to:
  - Trigger CI on changes to workflow YAML files.
  - Use Go 1.24 for builds and tests.
  - Add Python setup and install dependencies for secret detection and YAML linting.
  - Include steps for `go mod tidy` checks, `gofmt`, `go vet`, `staticcheck`, `yamllint`, secret scanning, and uncommitted changes detection. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR9) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL21-R58) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR71-R89) [[4]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL53-L61)

**Codebase Consistency and Minor Refactors**

* Standardized import aliases for decoder packages in Go encoder files and tests, improving code readability and maintainability. [[1]](diffhunk://#diff-f32657d8a1b21dd4d581de9b311b436a0b16cefc0e815230cd9cda8afffca303L8-R8) [[2]](diffhunk://#diff-6169d629e596dbc6e98d0462dde0bb3bb0606c4fab2b5487b986f71cfa96c21aL10-R10) [[3]](diffhunk://#diff-75d4632a81d6ea8a4a0744aaafe20113814c0bc058a8a3fd5489f6fee4d6db18L8-R8) [[4]](diffhunk://#diff-82fa8dc647044300504f167923ec6c84c6e602b5eb912d524ba48d323714f809L9-R9) [[5]](diffhunk://#diff-c356f829376ebc294fb3001f8736a9b00d3ec4a80731c60058ae2c0aebbd6df0L8-R8) [[6]](diffhunk://#diff-fd5dc7fcd80a046ae26b6f5a0c7ca395fd4ed3cb8ae8f1278e442ed86dbf9355L10-R10)
* Updated Prometheus metric label names in `pkg/solver/loracloud/metrics.go` from `"devEUI"` to `"devEui"` for consistency.

**Other Minor Changes**

* Ensured consistent YAML quoting style in `deployment/deployment.yaml` for command arguments.