### PR TITLE
Update GNSS port handling to always use port 192 in decoder and tests

### DIFF
--- a/pkg/decoder/tagxl/v1/decoder.go
+++ b/pkg/decoder/tagxl/v1/decoder.go
@@ -424,7 +424,7 @@ func (t TagXLv1Decoder) Decode(ctx context.Context, data string, port uint8) (*d
 			opts := solver.SolverV2Options{
 				DevEui:        devEui,
 				UplinkCounter: uint16(fcnt),
-				Port:          port,
+				Port:          192, // always 192 for GNSS NAV grouping
 				Timestamp:     tsPtr,
 				Moving:        movingPtr,
 			}

--- a/pkg/decoder/tagxl/v1/examples_test.go
+++ b/pkg/decoder/tagxl/v1/examples_test.go
@@ -238,8 +238,8 @@ func TestTagXL_GNSS_Port194_Timestamped(t *testing.T) {
 		if cap.lastPayload != expectedForwarded {
 			t.Fatalf("expected forwarded payload %q, got %q", expectedForwarded, cap.lastPayload)
 		}
-		if cap.lastOptions.Port != 194 {
-			t.Fatalf("expected port 194, got %d", cap.lastOptions.Port)
+		if cap.lastOptions.Port != 192 {
+			t.Fatalf("expected port 192, got %d", cap.lastOptions.Port)
 		}
 		if cap.lastOptions.Moving == nil || *cap.lastOptions.Moving != false {
 			t.Fatalf("expected Moving=false for port 194, got %+v", cap.lastOptions.Moving)
@@ -290,8 +290,8 @@ func TestTagXL_GNSS_Port195_Timestamped(t *testing.T) {
 		if cap.lastPayload != expectedForwarded {
 			t.Fatalf("expected forwarded payload %q, got %q", expectedForwarded, cap.lastPayload)
 		}
-		if cap.lastOptions.Port != 195 {
-			t.Fatalf("expected port 195, got %d", cap.lastOptions.Port)
+		if cap.lastOptions.Port != 192 {
+			t.Fatalf("expected port 192, got %d", cap.lastOptions.Port)
 		}
 		if cap.lastOptions.Moving == nil || *cap.lastOptions.Moving != true {
 			t.Fatalf("expected Moving=true for port 195, got %+v", cap.lastOptions.Moving)

--- a/pkg/decoder/tagxl/v1/gnss_v2_test.go
+++ b/pkg/decoder/tagxl/v1/gnss_v2_test.go
@@ -102,8 +102,8 @@ func TestGNSS_SolverV2_192_193_NoTimestamp(t *testing.T) {
 	if cap.lastPayload != payload {
 		t.Fatalf("expected payload forwarded unchanged for port 193, got %q", cap.lastPayload)
 	}
-	if cap.lastOptions.Port != 193 {
-		t.Fatalf("expected port 193, got %d", cap.lastOptions.Port)
+	if cap.lastOptions.Port != 192 {
+		t.Fatalf("expected port 192, got %d", cap.lastOptions.Port)
 	}
 	if cap.lastOptions.Moving == nil || *cap.lastOptions.Moving != true {
 		t.Fatalf("expected Moving=true for port 193, got %+v", cap.lastOptions.Moving)
@@ -159,8 +159,8 @@ func TestGNSS_SolverV2_194_195_TimestampStrippedAndPassed(t *testing.T) {
 	if cap.lastPayload != expectedForwarded {
 		t.Fatalf("expected forwarded payload %q, got %q", expectedForwarded, cap.lastPayload)
 	}
-	if cap.lastOptions.Port != 194 {
-		t.Fatalf("expected port 194, got %d", cap.lastOptions.Port)
+	if cap.lastOptions.Port != 192 {
+		t.Fatalf("expected port 192, got %d", cap.lastOptions.Port)
 	}
 	if cap.lastOptions.Moving == nil || *cap.lastOptions.Moving != false {
 		t.Fatalf("expected Moving=false for port 194, got %+v", cap.lastOptions.Moving)
@@ -180,8 +180,8 @@ func TestGNSS_SolverV2_194_195_TimestampStrippedAndPassed(t *testing.T) {
 	if cap.lastPayload != expectedForwarded {
 		t.Fatalf("expected forwarded payload %q, got %q", expectedForwarded, cap.lastPayload)
 	}
-	if cap.lastOptions.Port != 195 {
-		t.Fatalf("expected port 195, got %d", cap.lastOptions.Port)
+	if cap.lastOptions.Port != 192 {
+		t.Fatalf("expected port 192, got %d", cap.lastOptions.Port)
 	}
 	if cap.lastOptions.Moving == nil || *cap.lastOptions.Moving != true {
 		t.Fatalf("expected Moving=true for port 195, got %+v", cap.lastOptions.Moving)

--- a/pkg/solver/loracloud/v2/loracloud.go
+++ b/pkg/solver/loracloud/v2/loracloud.go
@@ -52,7 +52,7 @@ func NewLoracloudClient(ctx context.Context, accessToken string, logger *zap.Log
 		accessToken:       accessToken,
 		logger:            logger,
 		BaseUrl:           TraxmateLoRaCloudBaseUrl,
-		bufferedThreshold: time.Minute,
+		bufferedThreshold: 5 * time.Minute, // Default threshold for buffered detection
 	}
 	for _, opt := range options {
 		opt(&client)


### PR DESCRIPTION
This pull request standardizes the GNSS NAV grouping port to always use port 192 in the TagXL v1 decoder, replacing previous logic that used ports 193, 194, or 195. The associated tests have been updated to expect port 192 accordingly.

**Port standardization for GNSS NAV grouping:**

* Updated the `TagXLv1Decoder.Decode` method in `decoder.go` to always set the `Port` field to 192 for GNSS NAV grouping, instead of using the incoming port value.

**Test updates for port changes:**

* Modified tests in `examples_test.go` and `gnss_v2_test.go` to expect port 192 instead of 193, 194, or 195, ensuring alignment with the new decoder logic:
  - Updated port checks in `TestTagXL_GNSS_Port194_Timestamped` and `TestTagXL_GNSS_Port195_Timestamped` to expect 192. [[1]](diffhunk://#diff-802116153d505c1f57af32a1ed6a2a76646388013fa69ccf9ed699073ac73903L241-R242) [[2]](diffhunk://#diff-802116153d505c1f57af32a1ed6a2a76646388013fa69ccf9ed699073ac73903L293-R294)
  - Updated port checks in `TestGNSS_SolverV2_192_193_NoTimestamp` to expect 192.
  - Updated port checks in `TestGNSS_SolverV2_194_195_TimestampStrippedAndPassed` to expect 192 for both cases. [[1]](diffhunk://#diff-cf97fa0fd64a8b0c2ccfb6670e76961faaea4e83751ef05a1372c62e39f3f61dL162-R163) [[2]](diffhunk://#diff-cf97fa0fd64a8b0c2ccfb6670e76961faaea4e83751ef05a1372c62e39f3f61dL183-R184)