### PR TITLE
test(common): add coverage for incomplete TLV header error path

### DIFF
--- a/pkg/common/helpers_test.go
+++ b/pkg/common/helpers_test.go
@@ -162,6 +162,12 @@ func TestDecode(t *testing.T) {
 			expected:    nil,
 			expectedErr: "unsupported field type: time.Time",
 		},
+		{
+			payload:     "ffffffaa",
+			config:      tagConfig,
+			expected:    nil,
+			expectedErr: "incomplete TLV header",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Adds a single test case to pkg/common/helpers_test.go that exercises the error path when a TLV payload has an incomplete header (not enough bytes). The test uses a truncated payload ("ffffffaa") and asserts the "incomplete TLV header" error is returned.

This is a small coverage improvement — no functional changes, just closing a gap in the existing TestDecode table-driven tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for TLV header validation error scenarios with additional test case for incomplete header detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->