### PR TITLE
fix(loracloud): bump request timestamp by 1s on GNSS-NG EoG

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2212,7 +2212,7 @@
         "filename": "pkg/solver/loracloud/loracloud_test.go",
         "hashed_secret": "884f72cf02528dcd37a031e2af8575273d4394e2",
         "is_verified": false,
-        "line_number": 228,
+        "line_number": 356,
         "is_secret": false
       },
       {
@@ -2220,7 +2220,7 @@
         "filename": "pkg/solver/loracloud/loracloud_test.go",
         "hashed_secret": "56a889aac5ddc1816be3e5604074cf3e50c70500",
         "is_verified": false,
-        "line_number": 351,
+        "line_number": 479,
         "is_secret": false
       }
     ],
@@ -2235,5 +2235,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-28T18:24:36Z"
+  "generated_at": "2026-05-28T10:25:32Z"
 }

--- a/pkg/solver/loracloud/loracloud.go
+++ b/pkg/solver/loracloud/loracloud.go
@@ -230,6 +230,14 @@ func (m LoracloudClient) DeliverUplinkMessage(devEui string, uplinkMsg UplinkMsg
 		return nil, err
 	}
 
+	// EoG uplinks share the same RX second as the prior captures in their group.
+	// Bumping the request timestamp by 1s lets Traxmate's GNSS-NG solver order the
+	// EoG message after the rest of the group.
+	if header.EndOfGroup && uplinkMsg.Timestamp != nil {
+		adjusted := *uplinkMsg.Timestamp + 1
+		uplinkMsg.Timestamp = &adjusted
+	}
+
 	url := fmt.Sprintf("%v/api/v1/device/send", m.BaseUrl)
 
 	// format devEui to match ^([0-9a-fA-F]){2}(-([0-9a-fA-F]){2}){7}$

--- a/pkg/solver/loracloud/loracloud_test.go
+++ b/pkg/solver/loracloud/loracloud_test.go
@@ -2,6 +2,7 @@ package loracloud
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +16,8 @@ import (
 	"github.com/truvami/decoder/pkg/decoder"
 	"go.uber.org/zap"
 )
+
+func float64Ptr(v float64) *float64 { return &v }
 
 func startMockServer(handler http.Handler) *httptest.Server {
 	server := httptest.NewServer(handler)
@@ -206,6 +209,131 @@ func TestDeliverUplinkMessage(t *testing.T) {
 			t.Errorf("expected decoding error, got: %v", err)
 		}
 	})
+}
+
+func TestDeliverUplinkMessage_EndOfGroupTimestampAdjustment(t *testing.T) {
+	successResponse := []byte(`{
+		"result": {
+			"deveui": "01-23-45-67-89-AB-CD-EF",
+			"position_solution": {
+				"algorithm_type": "gnssng",
+				"llh": [51.49278, 0.0212, 83.93],
+				"accuracy": 20.7,
+				"gdop": 2.48,
+				"capture_time_utc": 1722433373.18046
+			},
+			"operation": "gnss"
+		}
+	}`)
+
+	tests := []struct {
+		name           string
+		payload        string
+		inputTimestamp *float64
+		wantTimestamp  *float64
+	}{
+		{
+			name:           "end of group bumps timestamp by 1s",
+			payload:        "80",
+			inputTimestamp: float64Ptr(1722433373),
+			wantTimestamp:  float64Ptr(1722433374),
+		},
+		{
+			name:           "not end of group leaves timestamp untouched",
+			payload:        "01",
+			inputTimestamp: float64Ptr(1722433373),
+			wantTimestamp:  float64Ptr(1722433373),
+		},
+		{
+			name:           "end of group with nil timestamp stays nil",
+			payload:        "80",
+			inputTimestamp: nil,
+			wantTimestamp:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedTimestamp *float64
+			var captured bool
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/device/send", func(w http.ResponseWriter, r *http.Request) {
+				var body struct {
+					Uplink struct {
+						Timestamp *float64 `json:"timestamp"`
+					} `json:"uplink"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("failed to decode request body: %v", err)
+				}
+				capturedTimestamp = body.Uplink.Timestamp
+				captured = true
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(successResponse)
+			})
+
+			server := startMockServer(mux)
+			defer server.Close()
+			middleware, err := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample(), WithBaseUrl(server.URL))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			_, err = middleware.DeliverUplinkMessage("0123456789ABCDEF", UplinkMsg{
+				MsgType:   "updf",
+				FCount:    1,
+				Port:      192,
+				Payload:   tt.payload,
+				Timestamp: tt.inputTimestamp,
+			})
+			assert.NoError(t, err)
+			assert.True(t, captured, "expected request to reach the mock server")
+			assert.Equal(t, tt.wantTimestamp, capturedTimestamp)
+		})
+	}
+}
+
+func TestDeliverUplinkMessage_EndOfGroupDoesNotMutateCallerTimestamp(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/device/send", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"result": {
+				"deveui": "01-23-45-67-89-AB-CD-EF",
+				"position_solution": {
+					"algorithm_type": "gnssng",
+					"llh": [51.49278, 0.0212, 83.93],
+					"accuracy": 20.7,
+					"gdop": 2.48,
+					"capture_time_utc": 1722433373.18046
+				},
+				"operation": "gnss"
+			}
+		}`))
+	})
+
+	server := startMockServer(mux)
+	defer server.Close()
+	middleware, err := NewLoracloudClient(context.TODO(), "access_token", zap.NewExample(), WithBaseUrl(server.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	original := float64(1722433373)
+	uplinkMsg := UplinkMsg{
+		MsgType:   "updf",
+		FCount:    1,
+		Port:      192,
+		Payload:   "80",
+		Timestamp: &original,
+	}
+
+	_, err = middleware.DeliverUplinkMessage("0123456789ABCDEF", uplinkMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1722433373), *uplinkMsg.Timestamp, "caller's timestamp pointer must not be mutated")
 }
 
 func TestResponseVariants(t *testing.T) {


### PR DESCRIPTION
## Summary
- When the GNSS-NG header `EoG` bit is set on a Tag XL uplink, add 1 second to the request `timestamp` sent to LoRaCloud/Traxmate so the EoG message sorts strictly after the prior captures in the same group.
- Applied in `DeliverUplinkMessage` after the header is decoded, so both the v1 and v2 `Solve` paths benefit. The response-side `GetTimestamp()` surface is unchanged.
- New pointer is allocated so the caller's `*float64` is never mutated.

## Test plan
- [x] `go test ./pkg/solver/loracloud/...`
- [x] `go test ./pkg/decoder/tagxl/...`
- [x] `go test ./...`
- [x] New tests: EoG bumps by 1s, non-EoG untouched, nil timestamp stays nil, caller pointer not mutated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-of-group uplink detection now advances the outgoing request timestamp by 1 second before sending to the LoRa Cloud endpoint to ensure proper ordering.

* **Tests**
  * Added test coverage validating the end-of-group timestamp adjustment behavior.
  * Added test ensuring caller-provided timestamp values remain unchanged during processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truvami/decoder/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->